### PR TITLE
Fix for ender mod not breaking out of loop if it gets under y = 0

### DIFF
--- a/InfernalMobs/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ender.java
+++ b/InfernalMobs/src/main/java/atomicstryker/infernalmobs/common/mods/MM_Ender.java
@@ -81,7 +81,7 @@ public class MM_Ender extends MobModifier
         int z = MathHelper.floor(mob.posZ);
 
         boolean hitGround = false;
-        while (!hitGround && y < 96)
+        while (!hitGround && y < 96 && y > 0)
         {
             IBlockState bs = mob.world.getBlockState(new BlockPos(x, y - 1, z));
             if (bs.getMaterial().blocksMovement())


### PR DESCRIPTION
Was spam fighting endermen from a spawner deep in a roguelike dungeon, around y 15. Encountered enderman with Ender modifier, multiple times upon hit, server would freeze, then time out. I'm guessing the starting teleport point it randomized to had a y of less or near 0 and then kept going, I believe this PR should fix that. Issue probably exists as far back as mc 1.7.10 as that is the version I encountered it on.