### PR TITLE
[FinderCompass] Fix incorrect player position rounding for negative player coordinates.

### DIFF
--- a/FinderCompass/src/main/java/atomicstryker/findercompass/client/FinderCompassLogic.java
+++ b/FinderCompass/src/main/java/atomicstryker/findercompass/client/FinderCompassLogic.java
@@ -15,9 +15,7 @@ public class FinderCompassLogic
 
     private final BlockPos NullChunk = new BlockPos(0, 0, 0);
 
-    private int x;
-    private int y;
-    private int z;
+    private BlockPos oldPos;
     private long nextTime;
     private int seccounter;
 
@@ -48,11 +46,10 @@ public class FinderCompassLogic
                 nextTime = System.currentTimeMillis() + 1000L;
             }
 
-            if ((int) mc.player.posX != this.x || (int) mc.player.posY != this.y || (int) mc.player.posZ != this.z)
+            BlockPos pos = new BlockPos(mc.player.posX, mc.player.posY, mc.player.posZ);
+            if (!pos.equals(oldPos))
             {
-                x = (int) mc.player.posX;
-                y = (int) mc.player.posY;
-                z = (int) mc.player.posZ;
+                oldPos = pos;
                 movement = true;
             }
 
@@ -87,7 +84,8 @@ public class FinderCompassLogic
                     if (is15SecInterval || configInts[7] == 0)
                     {
                         coords =
-                                findNearestBlockChunkOfIDInRange(currentSetting, blockInts.getBlockID(), blockInts.getDamage(), x, y, z,
+                                findNearestBlockChunkOfIDInRange(currentSetting, blockInts.getBlockID(), blockInts.getDamage(),
+                                        pos.getX(), pos.getY(), pos.getZ(),
                                         configInts[3], configInts[4], configInts[5], configInts[6]);
                         if (coords != null && !coords.equals(NullChunk))
                         {


### PR DESCRIPTION
I noticed the problem when I was trying to set up an extremely tight lava detection for just behind walls I was digging into, but without producing spurious detection for lava that is further away.

I set up a radius of 3 and put a single lava block on the ground for testing. In one orientation (let's call it X) this worked fine, it would start detecting when I was within 3 blocks or less of the lava. But in the other orientation (let's call it Z) it would only detect the lava when I was within 2 blocks from one direction and from the opposite direction it would detect it already when I was within 4 blocks.

It turned out I was at negative world coordinates in the Z orientation, which displayed the problem, and I was at positive world coordinates in the X orientation, which worked fine.

The problem is the (int) casting of the floating point position. Here's my commit message:

    (int) casting rounds towards zero, but float positions need to be
    rounded down unconditionally (towards negative infinity) to produce the
    correct position.

    The problem was that for negative player coordinates the player's block
    position would be off by one.

    Constructing a new BlockPos() takes care of the correct rounding for us
    and makes the code more readable, as that can be used for comparisons.