### PR TITLE
[FinderCompass] Fix rendering of the compass needles - no more compass perforation.

### DIFF
--- a/FinderCompass/src/main/java/atomicstryker/findercompass/client/CompassRenderHook.java
+++ b/FinderCompass/src/main/java/atomicstryker/findercompass/client/CompassRenderHook.java
@@ -72,6 +72,8 @@ public class CompassRenderHook
     {
         // save modelview matrix for later restoration
         GL11.glPushMatrix();
+        // make the needle cover roughly the same elliptical shape as the default pixelled one
+        GL11.glScalef(1.7875f, 0.8125f, 1f);
         
         GL11.glRotatef(-angle, 0, 0, 1f); // rotate around z axis, which is in the icon middle after our translation
 

--- a/FinderCompass/src/main/java/atomicstryker/findercompass/client/CompassRenderHook.java
+++ b/FinderCompass/src/main/java/atomicstryker/findercompass/client/CompassRenderHook.java
@@ -91,7 +91,7 @@ public class CompassRenderHook
 
         // alternative native ogl code
         GL11.glBegin(GL11.GL_QUADS); // set ogl mode, need quads
-        GL11.glColor4f(r, g, b, 0.75F); // set color
+        GL11.glColor4f(r, g, b, 0.85F); // set color
 
         // now draw each glorious needle as single quad
         GL11.glVertex3d(-0.03D, -0.04D, 0.0D); // lower left

--- a/FinderCompass/src/main/java/atomicstryker/findercompass/client/coremod/FCTransformer.java
+++ b/FinderCompass/src/main/java/atomicstryker/findercompass/client/coremod/FCTransformer.java
@@ -111,7 +111,8 @@ public class FCTransformer implements IClassTransformer
                     // this bytecode is equivalent to this line: CompassRenderHook.renderItemHook(itemStack);
 
                     // now write our hook in, after the target node
-                    m.instructions.insertBefore(targetNode, toInject);
+                    // it needs to be rendered afterwards for the semi-transparency of the needles to not perforate the compass
+                    m.instructions.insert(targetNode, toInject);
                 }
                 break;
             }


### PR DESCRIPTION
The needles render correctly now, no more viewing the blocks behind the compass through the needles.

I had to fix several things in the rendering routines, but the main culprit was that the needles were rendered before the compass instead of after it. The early-rendered needles were already frontmost in the Z-buffer (by good luck rather than by correctness, more about that further down) when it was the compass's turn, so the compass was not drawn at all where the needles already got drawn, and consequently the transparency of the needles allowed the background to shine through.

Swapping the place where the rendering hook was patched into the byte code was not enough, though, as now the needles didn't show up at all. Turns out the empirically determined translation coordinates of 0.54, 0.52, 0.522 at the beginning are not 100% accurate. The coordinates can be calculated in order to get them as accurate as possible. X and Y are the ones easier to explain.

Most things in Minecraft are rendered into unit cubes that span from 0.0 to 1.0 in their own coordinate system. As the original texture has 16 pixels and the pivot pixel of the red needle is 8 and a half (the pivot is at the center of a pixel) pixels away from both the left and the bottom border, we get a ratio of 8.5 / 16 both times. `8.5 / 16 * 1.0 = 0.53125`.

By some kind of chance, the Z coordinate directly hugging the upper surface of the compass is also 0.53125, however, there's a different reason: Either the handle of the cube is at the bottom and the 1 pixel thick compass is centered inside the cube or the handle of the cube is in the middle and the 1 pixel thick compass is centered around the upper surface of the cube. I suspect the latter, but the outcome is the same: Half a cube's length plus half a pixel's distance: `0.5 + 0.5 / 16 = 0.53125`.

You can easily verify the Z coordinate if you remove the elevation of the needles. Then you'll see Z-fighting between the needles and the compass surface when using 0.53125 as the Z translation. Changing the translation ever so slightly - to 0.53130 for instance - will remove the Z-fighting, so 0.53125 must be correct.

So why were the needles drawn before swapping the rendering order? Well, because the original Z translation of the needles was allowed to leak out to the rendering that followed. It wasn't restored by a complementary translation in the opposite direction or by saving and restoring the modelview matrix. In effect, the rendering of the compass was pushed "into the screen", away from the player, by just the right amount to make all needles visible. `0.522 - (-0.01) = 0.522 + 0.01 = 0.532` - that's slightly greater than `0.53125` and thus makes the needles visible.

However, bad rendering artifacts can occur when transformations are allowed to leak out into foreign code. The right thing to do is to enclose code that uses transformations with a `glPushMatrix()` / `glPopMatrix()` pair. Supposedly, that's also more efficient than reversing your transformations by hand, as each transformation calculates a new 4 x 4 matrix, which can be costly depending on the nature of the operation. And it removes a point of failure, as you don't need to come up with a reverse transformation that matches exactly.

With the fixed rendering, darker needles were now harder to make out in the item hotbar against the dark surface of the compass. **So I took the liberty to increase the opacity from 0.75 to 0.85.** Arguably, one could increase it even more to 0.9 or 0.95, but I didn't want to go overboard with it ;-) _If you don't like or don't want this change, just ask me to revert it and I will change the pull request._

Also, the original pixelled compass is drawn in a tilted perspective and thus has its red needle sweep an elliptical shape, not a circle. The added needles were spinning in a circle, which didn't quite match up. **So I took the liberty to scale the shape the needles sweep over to an ellipse that closely resembles the one of the pixelled red needle.** I think it looks better now, but it's not 100%, as the original pixelled needle should have been drawn thicker when it points up or down. An oversight of the original artist. Also, it's likely a matter of taste. Anyway, the same holds here, _if you don't like or don't want this change, just ask me to revert it and I will amend the pull request._