### PR TITLE
new template rule features--see template_rules.txt

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -580,6 +580,7 @@ public class RuinTemplate
         int lineIndex = 0;
         int ruleIndex = 0;
         int groupIndex = 0;
+        int groupSize = 0;
         int repeatCountPrevious = 0;
         int variantIndex = 0;
         String line;
@@ -658,6 +659,14 @@ public class RuinTemplate
                         }
                         else
                         {
+                        	if (ruleIndex == groupIndex)
+                        	{
+                        		++groupSize;
+                        	}
+                        	else if (variantIndex == groupSize && debugging)
+                        	{
+                                debugPrinter.printf("template [%s] line [%d]: rule #%d has more variants than first rule in group (rule #%d with %d variants); excess will be ignored\n", name, lineIndex, ruleIndex, groupIndex, groupSize);
+                        	}
                             ++variantIndex;
                             if (debugging)
                             {
@@ -678,6 +687,7 @@ public class RuinTemplate
                             }
                         }
                         groupIndex = ++ruleIndex;
+                        groupSize = 1;
                         repeatCountPrevious = repeatCount;
                         variantIndex = 1;
                         if (isFirstRule)

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -659,14 +659,14 @@ public class RuinTemplate
                         }
                         else
                         {
-                        	if (ruleIndex == groupIndex)
-                        	{
-                        		++groupSize;
-                        	}
-                        	else if (variantIndex == groupSize && debugging)
-                        	{
+                            if (ruleIndex == groupIndex)
+                            {
+                                ++groupSize;
+                            }
+                            else if (variantIndex == groupSize && debugging)
+                            {
                                 debugPrinter.printf("template [%s] line [%d]: rule #%d has more variants than first rule in group (rule #%d with %d variants); excess will be ignored\n", name, lineIndex, ruleIndex, groupIndex, groupSize);
-                        	}
+                            }
                             ++variantIndex;
                             if (debugging)
                             {
@@ -1053,7 +1053,7 @@ public class RuinTemplate
             {
                 return repeatCount*variantRules.size();
             }
-            
+
             // A VariantRule object contains an array of different RuinTemplateRule objects assigned to the same rule
             // index. In a template file, it looks like this:
             //     rule1=0,100,dirt

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -148,7 +148,7 @@ public class RuinTemplateRule
                 // because of the prefix string
                 blockStrings[i] = commandrules[i + 1];
                 blockStrings[i] = restoreNBTTags(blockStrings[i], nbttags);
-                debugPrinter.println("template " + owner.getName() + " contains Command Block command: " + blockStrings[i] + " with meta: " + blockMDs[i]);
+                debugPrinter.println("template " + owner.getName() + " contains Command Block command: " + blockStrings[i] + " with meta: " + blockMDs[i] + " and weight: " + blockWeights[i]);
             }
         }
         // not command blocks
@@ -281,7 +281,7 @@ public class RuinTemplateRule
 
                 if (excessiveDebugging)
                 {
-                    debugPrinter.printf("rule alternative: %d, blockIDs[%s], blockMDs[%s], blockStrings[%s], specialflags:[%s]\n", i + 1, blockIDs[i], blockMDs[i], blockStrings[i], specialFlags[i]);
+                    debugPrinter.printf("rule alternative: %d, blockIDs[%s], blockMDs[%s], blockStrings[%s], specialflags:[%s], blockWeights:[%d]\n", i + 1, blockIDs[i], blockMDs[i], blockStrings[i], specialFlags[i], blockWeights[i]);
                 }
             }
         }

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -290,102 +290,80 @@ preserve_plants=0
 # should break or alter the behavior of existing template files.
 #
 # Block Weighting: Instead of repeating block IDs in a rule to manipulate their probabilities of occurrence, weighting factors may
-# now be used. This can make rules shorter and, in certain circumstances, more efficient. Apply a weight to an ID in a rule by
-# preceding it with a prefix of the form "<weight>*"; this is functionally equivalent to repeating the ID <weight> times. Valid
-# values are integers between 1 and 99999, inclusive. For example, the following rules are essentially identical, each producing
-# blocks of cobble, mossy cobble, and gravel with roughly 56%, 33%, and 11% likelihood, respectively:
+# now be used. This can make rules shorter and, in certain circumstances, more efficient. Apply a weight to an block in a rule by
+# preceding it with a prefix of the form "n*"; this is functionally equivalent to repeating the same block n times. Valid values
+# for n are integers between 1 and 99999, inclusive. For example, the following rules are essentially identical, each producing
+# blocks of cobble, mossy cobble, and gravel with the same likelihood:
 #     rule1=0,100,cobblestone,cobblestone,mossy_cobblestone,cobblestone,gravel,cobblestone,mossy_cobblestone,mossy_cobblestone,cobblestone
 #     rule2=0,100,5*cobblestone,gravel,3*mossy_cobblestone
-# Weights are optional. If no weight is specified for an ID in a rule, a weight of 1 is assumed.
+# Weights are optional. If no weight is specified for a block in a rule, a weight of 1 is assumed.
 #
 # Rule Variants: Consider a platform composed of many instances of the following rule3:
-#     rule3=0,100,wool-14,wool-4,wool-11
-# Each generated structure will have a different random assortment of red, yellow, and blue wool blocks. Suppose, though, what you
-# really want is each platform to be a single, randomly chosen color--either all red, all yellow, or all blue. You can't do that
-# with a regular rule, since a different color choice is made per block. You could do it with three separate templates, of course,
-# but now there's another way. For example:
-#     rule4=0,100,wool-14
-#     ^0,100,wool-4
-#     ^0,100,wool-11
-# Note "rule<number>=" is replaced by "^" to indicate a line is a variant of the preceding rule, not a separate rule itself. Each
-# time a structure with such a rule is generated, one of these variants is randomly chosen to apply to that entire structure
-# wherever the corresponding number appears in the level specification. Despite from the different syntax at the beginning of the
-# line, these are otherwise full-featured rules. You might, for example, build structures in varying degrees of dilapidation using
-# a rule like:
-#     rule5=0,95,5*cobblestone,mossy_cobblestone
-#     ^0,85,4*cobblestone,2*mossy_cobblestone,gravel
-#     ^0,75,cobblestone,mossy_cobblestone,gravel
-#     ^0,60,mossy_cobblestone,3*gravel
+#     rule3=0,100,stone,dirt,cobblestone
+# Each generated structure will have a different random assortment of stone, dirt, and cobblestone blocks. Suppose, though, what
+# you really want is each platform to be a single, randomly chosen material--either all stone, or all dirt, or all cobblestone.
+# You can't do that with a regular rule, since a different color choice is made per block. You could do it with three separate
+# templates, of course, but now there's another way. For example:
+#     rule4=0,100,stone
+#     ^0,100,dirt
+#     ^0,100,cobblestone
+# Note "ruleXXX=" is replaced by "^" to indicate a line is a variant of the preceding rule, not a separate rule itself. Each time
+# a structure with such a rule is generated, one of these variants is randomly chosen to apply to that entire structure wherever
+# the corresponding number appears in the layer specifications.
 #
 # Rule Variant Weighting: Weights can be applied to rule variants to adjust the probability with which they are selected. As with
-# block weighting, a prefix of the form "<weight>*" is placed at the beginning of the variant (i.e., just after the = or ^) to
-# assign it a weight. For example, you can use this rule for the windows in your structure:
+# block weighting, a prefix of the form "n*" is placed at the beginning of the variant (i.e., just after the = or ^) to assign it
+# a weight. For example, you can use this rule for the windows in your structure:
 #     rule6=3*0,100,2*stained_glass-14
 #     ^0,100,stained_glass-4
 #     ^5*0,100,stained_glass-11
-# Most of your generated structures will have blue windows, a little more than half as many will have red windows, and only a
-# precious few will have yellow ones. Really...who wants yellow windows, anyway?
+# Most of your generated structures will have blue windows (stained_glass-11, with a weight of 5), a little more than half as many
+# will have red windows (stained_glass-14, with a weight of 3), and only a precious few will have yellow ones (stained_glass-4,
+# with a weight of 1, the default when none is specified).
 #
 # Grouped Rule Variants: With variants, it may be desirable to coordinate several different rules to guarantee selections are
 # only made in particular combinations. A named rule specification using ^ instead of = creates a new rule whose variant choice
 # depends on that of the preceding rule. For example, make a small pillar with the following rule7 at the base and rule8 stacked
 # above it:
-#     rule7=5*0,100,log-0
-#     ^0,100,log-1
-#     ^2*0,100,log-2
-#     rule8^5*0,100,planks-0
-#     ^0,100,planks-1
-#     ^2*0,100,planks-2
-# Some of your pillars (5/8) will be made of oak, fewer (1/4) of birch, and fewer still (1/8) spruce. However, because the weights
-# are identical in these two rules, the logs and planks are always of the same wood type. There's no law that says the weights
-# have to be identical, though; this can be exploited to interesting effect. Consider stacks of the following rules, once again
-# from the bottom up, one block of each:
-#     rule9=5*0,100,stone
-#     rule10^4*0,100,8*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule11^3*0,100,4*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule12^2*0,100,2*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule13^0,100,stone,cobblestone
-#     ^0,100,preserveBlock
-# This example generates pillars of random height from 1-5 blocks, tending to be increasingly crumbly the taller they are. The
-# selection of which variants to use for rules in a particular group is always based on the first rule of that group (i.e., the
-# rule with an = instead of ^). In this case, the first rule effectively has 5 variants due to its weight of 5, even though they
-# are all identical. As a result, a variant index of 1 to 5 will be randomly chosen for this group per structure, and every one of
-# its constituent rules will use its variant corresponding to that same index in that structure. Suppose 3 is chosen. rule9 will
-# be stone, because it's always stone. rule 10's 3rd variant is 89% stone/11% cobble, rule11's is 80% stone/20% cobble. rule12's
-# 3rd variant is preserveBlock, so this pillar is only 3 blocks high. rule13 only has 2 variants--if the group selection goes past
-# the end of one its rules (rule13 has no 3rd variant), it simply uses the last one it does have, which in this case is another
-# preserveBlock.
+#     rule7=0,100,redstone_block
+#     ^0,100,gold_block
+#     ^0,100,lapis_block
+#     rule8^0,100,stained_glass-14
+#     ^0,100,stained_glass-4
+#     ^0,100,stained_glass-11
+# When a structure chooses variant #1 of rule7, it will always choose variant #1 of rule8 as well, so pillars with redstone at the
+# base will have red glass (stained_glass-14) on top. Similarly, gold blocks (rule7, variant #2) will be matched with yellow glass
+# (rule8, variant #2) and lapis (rule7, variant #3) with blue (rule8, variant #3).
 # 
-# Rule Variant Group Duplication: Suppose you have a structure with four crumbly pillars, as described in the previous example.
-# You could make four stacks of rules9 through 13. Different structures would have different pillar heights, sure, but all four
-# pillars of any one structure would be of the exact same height. To get variation within the same structure, you're going to need
-# a separate group of rules for each pillar--one using rule9,10,11,12,13, one using rule14,15,16,17,18...
-#     rule14=5*0,100,stone
-#     rule15^4*0,100,8*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule16^3*0,100,4*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule17^2*0,100,2*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule18^0,100,stone,cobblestone
-#     ^0,100,preserveBlock
-# ...one using rule19,20,21,22,23--but wait! These rule groups are identical except for their names, and there's an easier way. By
-# putting a repeat count of the form "<repeats>*" in front of the first rule name in a variant group (the one with an =), that
-# many identical groups are automatically created. This is a bit tricky, because it does create new rules, which affects the way
-# rules are numbered. To continue the example, rule9 could be changed slightly to take advantage of this feature:
-#     4*rule9=5*0,100,stone
-#     rule10^4*0,100,8*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule11^3*0,100,4*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule12^2*0,100,2*stone,cobblestone
-#     ^0,100,preserveBlock
-#     rule13^0,100,stone,cobblestone
-#     ^0,100,preserveBlock
-# This creates rule9 through rule13 as before, but also creates rule14 through rule28, so you don't have to.
+# Rule Variant Group Duplication: Suppose you have a structure with three fancy pillars, as described in the previous example.
+# You could make four stacks of rules7 and 8. Different structures would have different kinds of pillars, but all three pillars of
+# any one structure would be of the same type. To get variation within the same structure, you're going to need a separate group
+# of rules for each pillar--one using rule7 and 8, one using 9 and 10, and one using 11 and 12.
+#     rule9=0,100,redstone_block
+#     ^0,100,gold_block
+#     ^0,100,lapis_block
+#     rule10^0,100,stained_glass-14
+#     ^0,100,stained_glass-4
+#     ^0,100,stained_glass-11
+#     rule11=0,100,redstone_block
+#     ^0,100,gold_block
+#     ^0,100,lapis_block
+#     rule12^0,100,stained_glass-14
+#     ^0,100,stained_glass-4
+#     ^0,100,stained_glass-11
+# Note these rule groups are identical except for their names, and there's an easier way. By putting a repeat count of the form
+# "n*" in front of the first rule name in a variant group (the one with an =), that many identical groups are automatically
+# created. This is a bit tricky, because it does create new rules, which affects the way rules are numbered. To continue the
+# example, rule7 could be changed slightly to take advantage of this feature:
+#     3*rule7=0,100,redstone_block
+#     ^0,100,gold_block
+#     ^0,100,lapis_block
+#     rule8^0,100,stained_glass-14
+#     ^0,100,stained_glass-4
+#     ^0,100,stained_glass-11
+# This creates rule7 and 8 as before, but also creates rule9, 10, 11, and 12, exactly as though these lines were cut and pasted
+# into the template file 3 times. Note the rule names are irrelevant--rules are assigned numbers based on their ordinal position
+# in the template (the first rule is 1, the second 2, and so on, regardless of their names).
 #
 # Alternate Rule 0: By default, rule 0 is an air block. You can now change it to something else by putting an unnamed rule at the
 # top of your rule list:
@@ -397,8 +375,14 @@ preserve_plants=0
 #
 
 rule1=0,100,preserveBlock
-rule2=0,80,brick_block,brick_block,dirt,stone,gravel
+rule2=0,80,2*brick_block,dirt,stone,gravel
 rule3=0,100,brick_block
+rule4=2*0,100,log-0
+^0,100,log-2
+^0,100,log-1
+rule5^2*0,90,planks-0
+^0,80,planks-2
+^0,70,planks-1
 
 
 # LAYERS
@@ -412,9 +396,9 @@ rule3=0,100,brick_block
 layer
 2,2,2,2,2
 2,1,1,1,2
-2,1,1,1,2
-2,1,1,1,2
-2,1,1,1,2
+4,1,1,1,4
+4,1,1,1,4
+4,1,1,1,4
 2,1,1,1,2
 2,2,2,2,2
 endlayer
@@ -422,19 +406,9 @@ endlayer
 layer
 3,3,3,3,3
 3,0,0,0,3
-3,0,0,0,3
-3,0,0,0,3
-3,0,0,0,3
-3,0,0,0,3
-3,3,3,3,3
-endlayer
-
-layer
-3,3,3,3,3
-3,0,0,0,3
-3,0,0,0,3
-3,0,0,0,3
-3,0,0,0,3
+5,0,0,0,5
+5,0,0,0,5
+5,0,0,0,5
 3,0,0,0,3
 3,3,3,3,3
 endlayer
@@ -442,9 +416,19 @@ endlayer
 layer
 3,3,3,3,3
 3,0,0,0,3
+5,0,0,0,5
+5,0,0,0,5
+5,0,0,0,5
 3,0,0,0,3
+3,3,3,3,3
+endlayer
+
+layer
+3,3,3,3,3
 3,0,0,0,3
-3,0,0,0,3
+4,0,0,0,4
+4,5,5,5,4
+4,0,0,0,4
 3,0,0,0,3
 3,3,3,3,3
 endlayer

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -284,6 +284,117 @@ preserve_plants=0
 # Example: rule1=0,100,teBlock;minecraft:trapped_chest;{x:-156,y:65,z:72,Items:[0:{Slot:12b,id:5s,Count:1b,Damage:0s},1:{Slot:13b,id:24s,Count:1b,Damage:1s}],id:"Chest"}-2
 # Note: "Chain" and "Repeat" Command Blocks are classified as such by default
 #
+# --- begin proposal ---
+#
+# The rule syntax was modified a bit to add some new features (variants and variant groups, in particular). None of these changes
+# should break or alter the behavior of existing template files.
+#
+# Block Weighting: Instead of repeating block IDs in a rule to manipulate their probabilities of occurrence, weighting factors may
+# now be used. This can make rules shorter and, in certain circumstances, more efficient. Apply a weight to an ID in a rule by
+# preceding it with a prefix of the form "<weight>*"; this is functionally equivalent to repeating the ID <weight> times. Valid
+# values are integers between 1 and 99999, inclusive. For example, the following rules are essentially identical, each producing
+# blocks of cobble, mossy cobble, and gravel with roughly 56%, 33%, and 11% likelihood, respectively:
+#     rule1=0,100,cobblestone,cobblestone,mossy_cobblestone,cobblestone,gravel,cobblestone,mossy_cobblestone,mossy_cobblestone,cobblestone
+#     rule2=0,100,5*cobblestone,gravel,3*mossy_cobblestone
+# Weights are optional. If no weight is specified for an ID in a rule, a weight of 1 is assumed.
+#
+# Rule Variants: Consider a platform composed of many instances of the following rule3:
+#     rule3=0,100,wool-14,wool-4,wool-11
+# Each generated structure will have a different random assortment of red, yellow, and blue wool blocks. Suppose, though, what you
+# really want is each platform to be a single, randomly chosen color--either all red, all yellow, or all blue. You can't do that
+# with a regular rule, since a different color choice is made per block. You could do it with three separate templates, of course,
+# but now there's another way. For example:
+#     rule4=0,100,wool-14
+#     ^0,100,wool-4
+#     ^0,100,wool-11
+# Note "rule<number>=" is replaced by "^" to indicate a line is a variant of the preceding rule, not a separate rule itself. Each
+# time a structure with such a rule is generated, one of these variants is randomly chosen to apply to that entire structure
+# wherever the corresponding number appears in the level specification. Despite from the different syntax at the beginning of the
+# line, these are otherwise full-featured rules. You might, for example, build structures in varying degrees of dilapidation using
+# a rule like:
+#     rule5=0,95,5*cobblestone,mossy_cobblestone
+#     ^0,85,4*cobblestone,2*mossy_cobblestone,gravel
+#     ^0,75,cobblestone,mossy_cobblestone,gravel
+#     ^0,60,mossy_cobblestone,3*gravel
+#
+# Rule Variant Weighting: Weights can be applied to rule variants to adjust the probability with which they are selected. As with
+# block weighting, a prefix of the form "<weight>*" is placed at the beginning of the variant (i.e., just after the = or ^) to
+# assign it a weight. For example, you can use this rule for the windows in your structure:
+#     rule6=3*0,100,2*stained_glass-14
+#     ^0,100,stained_glass-4
+#     ^5*0,100,stained_glass-11
+# Most of your generated structures will have blue windows, a little more than half as many will have red windows, and only a
+# precious few will have yellow ones. Really...who wants yellow windows, anyway?
+#
+# Grouped Rule Variants: With variants, it may be desirable to coordinate several different rules to guarantee selections are
+# only made in particular combinations. A named rule specification using ^ instead of = creates a new rule whose variant choice
+# depends on that of the preceding rule. For example, make a small pillar with the following rule7 at the base and rule8 stacked
+# above it:
+#     rule7=5*0,100,log-0
+#     ^0,100,log-1
+#     ^2*0,100,log-2
+#     rule8^5*0,100,planks-0
+#     ^0,100,planks-1
+#     ^2*0,100,planks-2
+# Some of your pillars (5/8) will be made of oak, fewer (1/4) of birch, and fewer still (1/8) spruce. However, because the weights
+# are identical in these two rules, the logs and planks are always of the same wood type. There's no law that says the weights
+# have to be identical, though; this can be exploited to interesting effect. Consider stacks of the following rules, once again
+# from the bottom up, one block of each:
+#     rule9=5*0,100,stone
+#     rule10^4*0,100,8*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule11^3*0,100,4*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule12^2*0,100,2*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule13^0,100,stone,cobblestone
+#     ^0,100,preserveBlock
+# This example generates pillars of random height from 1-5 blocks, tending to be increasingly crumbly the taller they are. The
+# selection of which variants to use for rules in a particular group is always based on the first rule of that group (i.e., the
+# rule with an = instead of ^). In this case, the first rule effectively has 5 variants due to its weight of 5, even though they
+# are all identical. As a result, a variant index of 1 to 5 will be randomly chosen for this group per structure, and every one of
+# its constituent rules will use its variant corresponding to that same index in that structure. Suppose 3 is chosen. rule9 will
+# be stone, because it's always stone. rule 10's 3rd variant is 89% stone/11% cobble, rule11's is 80% stone/20% cobble. rule12's
+# 3rd variant is preserveBlock, so this pillar is only 3 blocks high. rule13 only has 2 variants--if the group selection goes past
+# the end of one its rules (rule13 has no 3rd variant), it simply uses the last one it does have, which in this case is another
+# preserveBlock.
+# 
+# Rule Variant Group Duplication: Suppose you have a structure with four crumbly pillars, as described in the previous example.
+# You could make four stacks of rules9 through 13. Different structures would have different pillar heights, sure, but all four
+# pillars of any one structure would be of the exact same height. To get variation within the same structure, you're going to need
+# a separate group of rules for each pillar--one using rule9,10,11,12,13, one using rule14,15,16,17,18...
+#     rule14=5*0,100,stone
+#     rule15^4*0,100,8*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule16^3*0,100,4*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule17^2*0,100,2*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule18^0,100,stone,cobblestone
+#     ^0,100,preserveBlock
+# ...one using rule19,20,21,22,23--but wait! These rule groups are identical except for their names, and there's an easier way. By
+# putting a repeat count of the form "<repeats>*" in front of the first rule name in a variant group (the one with an =), that
+# many identical groups are automatically created. This is a bit tricky, because it does create new rules, which affects the way
+# rules are numbered. To continue the example, rule9 could be changed slightly to take advantage of this feature:
+#     4*rule9=5*0,100,stone
+#     rule10^4*0,100,8*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule11^3*0,100,4*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule12^2*0,100,2*stone,cobblestone
+#     ^0,100,preserveBlock
+#     rule13^0,100,stone,cobblestone
+#     ^0,100,preserveBlock
+# This creates rule9 through rule13 as before, but also creates rule14 through rule28, so you don't have to.
+#
+# Alternate Rule 0: By default, rule 0 is an air block. You can now change it to something else by putting an unnamed rule at the
+# top of your rule list:
+#     =0,100,stained_glass-7,stained_glass-8
+# It has to appear before any other rule. It cannot be a variant of a preceding rule (since there isn't one--it has to start with
+# = instead of ^), but it can be followed by variants and/or grouped variant rules. It cannot have a repeat count. 
+#
+# --- end proposal ---
+#
 
 rule1=0,100,preserveBlock
 rule2=0,80,brick_block,brick_block,dirt,stone,gravel


### PR DESCRIPTION
I needed per-structure random draws in addition to per-block (so, for example, the walls of some structures might be all oak planks and others all spruce, and the half the oak structures might have cobblestone floors, while the other half and all the spruce ones have dirt...stuff like that). With the current rules, the best you can do is get a jumble of oak and spruce and cobble and dirt in every structure, or make separate templates for each desired combination. My solution was "rule variants"; maybe this has general usefulness.