### PR TITLE
Fix GUI overlay not being displayed.

### DIFF
--- a/InfernalMobs/src/main/java/atomicstryker/infernalmobs/client/InfernalMobsClient.java
+++ b/InfernalMobs/src/main/java/atomicstryker/infernalmobs/client/InfernalMobsClient.java
@@ -187,8 +187,8 @@ public class InfernalMobsClient implements ISidedProxy
                 Entity pointedEntity = null;
                 for (Object obj : mc.world.getEntitiesWithinAABBExcludingEntity(mc.getRenderViewEntity(),
                         mc.getRenderViewEntity().getEntityBoundingBox()
-                                .offset(viewEntityLookVec.x * reachDistance, viewEntityLookVec.y * reachDistance, viewEntityLookVec.z * reachDistance)
-                                .expand((double) expandBBvalue, (double) expandBBvalue, (double) expandBBvalue)))
+                                .expand(viewEntityLookVec.x * reachDistance, viewEntityLookVec.y * reachDistance, viewEntityLookVec.z * reachDistance)
+                                .grow((double) expandBBvalue, (double) expandBBvalue, (double) expandBBvalue)))
                 {
                     iterEnt = (Entity) obj;
                     if (iterEnt.canBeCollidedWith())


### PR DESCRIPTION
The wrong mappings were used in getEntityCrosshairOver during a recent update. This corrects the mappings and fixes the GUI overlay.