### PR TITLE
reduce log spamming

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
@@ -40,11 +40,12 @@ class CommandTestTemplate extends CommandBase
     public void execute(MinecraftServer server, ICommandSender sender, String[] args)
     {
         EntityPlayer player = sender.getEntityWorld().getPlayerEntityByName(sender.getName());
+        boolean is_player = player != null;
         int xpos, ypos, zpos;
         xpos = sender.getPosition().getX();
         ypos = sender.getPosition().getY();
         zpos = sender.getPosition().getZ();
-        if (player != null && args.length < 4)
+        if (is_player && args.length < 4)
         {
             if (args.length < 1)
             {
@@ -60,7 +61,7 @@ class CommandTestTemplate extends CommandBase
             }
             else
             {
-                tryBuild(sender, args, xpos, ypos - 1, zpos);
+                tryBuild(sender, args, xpos, ypos - 1, zpos, is_player);
             }
         }
         else if (args.length >= 4)
@@ -69,12 +70,12 @@ class CommandTestTemplate extends CommandBase
             {
                 if (args[2].equals("_"))
                 {
-                    tryBuild(sender, args, (int) parseDouble(xpos, args[1], -30000000, 30000000, false), -1, (int) parseDouble(zpos, args[3], -30000000, 30000000, false));
+                    tryBuild(sender, args, (int) parseDouble(xpos, args[1], -30000000, 30000000, false), -1, (int) parseDouble(zpos, args[3], -30000000, 30000000, false), is_player);
                 }
                 else
                 {
                     tryBuild(sender, args, (int) parseDouble(xpos, args[1], -30000000, 30000000, false), (int) parseDouble(ypos, args[2], -30000000, 30000000, false) - 1,
-                            (int) parseDouble(zpos, args[3], -30000000, 30000000, false));
+                            (int) parseDouble(zpos, args[3], -30000000, 30000000, false), is_player);
                 }
             }
             catch (NumberInvalidException e)
@@ -88,7 +89,7 @@ class CommandTestTemplate extends CommandBase
         }
     }
 
-    private void tryBuild(ICommandSender sender, String[] args, int x, int y, int z)
+    private void tryBuild(ICommandSender sender, String[] args, int x, int y, int z, boolean is_player)
     {
         String target = args[0];
         if (!target.contains("/"))
@@ -101,7 +102,7 @@ class CommandTestTemplate extends CommandBase
         {
             try
             {
-                parsedRuin = new RuinTemplate(new PrintWriter(System.out, true), file.getCanonicalPath(), file.getName(), true);
+                parsedRuin = new RuinTemplate(new PrintWriter(System.out, true), file.getCanonicalPath(), file.getName(), is_player);
                 int rotation = (args.length > 4) ? Integer.parseInt(args[4]) : RuinsMod.DIR_NORTH;
 
                 if (parsedRuin != null)
@@ -126,7 +127,7 @@ class CommandTestTemplate extends CommandBase
                         }
                     }
 
-                    if (MinecraftForge.EVENT_BUS.post(new EventRuinTemplateSpawn(sender.getEntityWorld(), parsedRuin, x, y, z, rotation, true, true)))
+                    if (MinecraftForge.EVENT_BUS.post(new EventRuinTemplateSpawn(sender.getEntityWorld(), parsedRuin, x, y, z, rotation, is_player, true)))
                     {
                         sender.sendMessage(new TextComponentTranslation("EventRuinTemplateSpawn returned as cancelled, not building that."));
                     }
@@ -135,7 +136,7 @@ class CommandTestTemplate extends CommandBase
                         int resultY = parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, x, y, z, rotation);
                         if (resultY > 0)
                         {
-                            MinecraftForge.EVENT_BUS.post(new EventRuinTemplateSpawn(sender.getEntityWorld(), parsedRuin, x, resultY, z, rotation, true, false));
+                            MinecraftForge.EVENT_BUS.post(new EventRuinTemplateSpawn(sender.getEntityWorld(), parsedRuin, x, resultY, z, rotation, is_player, false));
                         }
                         parsedRuin = null;
                     }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -165,7 +165,10 @@ public class RuinTemplateRule
                 // because of the prefix string
                 blockStrings[i] = commandrules[i + 1];
                 blockStrings[i] = restoreNBTTags(blockStrings[i], nbttags);
-                debugPrinter.println("template " + owner.getName() + " contains Command Block command: " + blockStrings[i] + " with meta: " + blockMDs[i] + ", weight: " + blockWeights[i] + ", preserve: " + preservePolicies[i]);
+                if (excessiveDebugging)
+                {
+                    debugPrinter.println("template " + owner.getName() + " contains Command Block command: " + blockStrings[i] + " with meta: " + blockMDs[i] + ", weight: " + blockWeights[i] + ", preserve: " + preservePolicies[i]);
+                }
             }
         }
         // not command blocks
@@ -357,7 +360,10 @@ public class RuinTemplateRule
             }
             String capture = rule.substring(openingIndex, closingIndex + 1);
             nbttags.add(capture);
-            debugPrinter.println("template " + owner.getName() + " contains nbt tag: " + capture);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("template " + owner.getName() + " contains nbt tag: " + capture);
+            }
             String pre = rule.substring(0, openingIndex);
             String post = rule.substring(closingIndex + 1, rule.length());
             rule = pre + "NBT" + nbttags.size() + post;
@@ -795,19 +801,28 @@ public class RuinTemplateRule
         }
         else if (dataString.startsWith("teBlock;"))
         {
-            debugPrinter.println("teBlock about to be placed: " + dataString);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("teBlock about to be placed: " + dataString);
+            }
             // examples: teBlock;minecraft:trapped_chest;{...nbt json...},
             // teBlock;minecraft:trapped_chest;{...nbt json...}-4
             String[] in = dataString.split(";");
             Block b = Block.REGISTRY.getObject(new ResourceLocation(in[1]));
-            debugPrinter.println("teBlock object from [" + in[1] + "]: " + b);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("teBlock object from [" + in[1] + "]: " + b);
+            }
             if (b != Blocks.AIR)
             {
                 BlockPos p = new BlockPos(x, y, z);
                 try
                 {
                     NBTTagCompound tc = JsonToNBT.getTagFromJson(in[2].substring(0, in[2].lastIndexOf('}') + 1));
-                    debugPrinter.println("teBlock read, decoded nbt tag: " + tc.toString());
+                    if (excessiveDebugging)
+                    {
+                        debugPrinter.println("teBlock read, decoded nbt tag: " + tc.toString());
+                    }
                     world.setBlockState(p, b.getStateFromMeta(blockMDs[blocknum]), rotate);
                     TileEntity tenew = TileEntity.create(world, tc);
                     world.removeTileEntity(p);
@@ -1030,7 +1045,10 @@ public class RuinTemplateRule
 
             List<ItemStack> lootFromPools = loottable.generateLootForPools(random, lootContextBuilder.build());
             int toRemove = lootFromPools.size() - targetCount;
-            debugPrinter.println("addChestGenChest running with gen[" + gen + "], loot pool size " + lootFromPools.size() + ", targetCount " + targetCount);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("addChestGenChest running with gen[" + gen + "], loot pool size " + lootFromPools.size() + ", targetCount " + targetCount);
+            }
             if (targetCount > 0 && toRemove > 0)
             {
                 Collections.shuffle(lootFromPools);
@@ -1042,7 +1060,10 @@ public class RuinTemplateRule
                     toRemove--;
                 }
             }
-            debugPrinter.println("addChestGenChest post removal loot pool size " + lootFromPools.size());
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("addChestGenChest post removal loot pool size " + lootFromPools.size());
+            }
 
             List<Integer> emptySlotsRandomized = getEmptySlotsRandomized(chest, random);
             shuffleItems(lootFromPools, emptySlotsRandomized.size(), random);
@@ -1175,10 +1196,16 @@ public class RuinTemplateRule
         String[] itemStrings = itemDataWithoutNBT.split(Pattern.quote("+"));
         String[] hashsplit;
         Object o;
-        debugPrinter.println("itemStrings length: " + itemStrings.length);
+        if (excessiveDebugging)
+        {
+            debugPrinter.println("itemStrings length: " + itemStrings.length);
+        }
         for (String itemstring : itemStrings)
         {
-            debugPrinter.println("itemString: " + itemstring);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("itemString: " + itemstring);
+            }
             hashsplit = itemstring.split("#");
 
             int itemStackSize = 1;
@@ -1195,7 +1222,10 @@ public class RuinTemplateRule
             int itemMeta = hashsplit.length > 2 ? Integer.valueOf(hashsplit[2]) : 0;
             int targetslot = hashsplit.length > 3 ? Integer.valueOf(hashsplit[3]) : -1;
             o = tryFindingObject(hashsplit[0]);
-            debugPrinter.println(hashsplit[0] + " resolved to object " + o);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println(hashsplit[0] + " resolved to object " + o);
+            }
 
             putItem = null;
             if (o instanceof Block)
@@ -1206,7 +1236,10 @@ public class RuinTemplateRule
             {
                 putItem = new ItemStack(((Item) o), itemStackSize, itemMeta);
             }
-            debugPrinter.println("itemstack instance: " + putItem);
+            if (excessiveDebugging)
+            {
+                debugPrinter.println("itemstack instance: " + putItem);
+            }
 
             if (putItem != null)
             {
@@ -1215,7 +1248,10 @@ public class RuinTemplateRule
                     try
                     {
                         hashsplit[1] = restoreNBTTags(hashsplit[1], nbtTags);
-                        debugPrinter.println("trying to apply nbt tag: " + hashsplit[1]);
+                        if (excessiveDebugging)
+                        {
+                            debugPrinter.println("trying to apply nbt tag: " + hashsplit[1]);
+                        }
                         putItem.setTagCompound(JsonToNBT.getTagFromJson(hashsplit[1]));
                     }
                     catch (NBTException e)


### PR DESCRIPTION
I notice folks are cleverly using the /testruin command in command blocks, but it seems to have been designed with just testing in mind, not general use--it floods the log with all sorts of trace and debug messages which aren't particularly useful in a non-testing context. These changes squash the extraneous logging when the command wasn't issued by a player.