### PR TITLE
recognize ALL the airs!

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -334,7 +334,7 @@ public class RuinTemplate
         RuinTemplateRule curRule;
 
         // height sanity check
-        final int y = Math.max(Math.min(yBase, world.getActualHeight() - height), 8);
+        int y = Math.max(Math.min(yBase, world.getActualHeight() - height), 8);
 
         // initialize all these variables
         final ArrayList<RuinRuleProcess> laterun = new ArrayList<>();
@@ -342,7 +342,10 @@ public class RuinTemplate
         final Iterator<RuinTemplateLayer> layeriter = layers.iterator();
 
         int y_off = (1 - embed) + ((randomOffMax != randomOffMin) ? random.nextInt(randomOffMax - randomOffMin) : 0) + randomOffMin;
-        int yReturn = y + y_off;
+
+        // height sanity check redux
+        int yReturn = Math.max(Math.min(y + y_off, world.getActualHeight() - height), 8);
+        y = yReturn - y_off;
 
         // override rotation wishes if its locked by template
         if (preventRotation)

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -914,7 +914,7 @@ public class RuinTemplateRule
             addCustomSpawner(world, x, y, z, "Skeleton");
             break;
         case 2:
-            addCustomSpawner(world, x, y, z, "CaveSpider");
+            addCustomSpawner(world, x, y, z, "Cave_Spider");
             break;
         default:
             addCustomSpawner(world, x, y, z, "Zombie");
@@ -930,7 +930,7 @@ public class RuinTemplateRule
             addCustomSpawner(world, x, y, z, "Creeper");
             break;
         case 1:
-            addCustomSpawner(world, x, y, z, "CaveSpider");
+            addCustomSpawner(world, x, y, z, "Cave_Spider");
             break;
         case 2:
             addCustomSpawner(world, x, y, z, "Skeleton");
@@ -1516,7 +1516,7 @@ public class RuinTemplateRule
         // this method is unused if the direction is NORTH
         int tempdata = 0;
 
-        if (blockID == Blocks.RAIL || blockID == Blocks.GOLDEN_RAIL || blockID == Blocks.DETECTOR_RAIL || blockID == Blocks.ACTIVATOR_RAIL)
+        if (blockID == Blocks.RAIL)
         {
             // minecart tracks
             switch (dir)
@@ -1652,6 +1652,96 @@ public class RuinTemplateRule
                 if (metadata == 9)
                 {
                     return 8;
+                }
+            }
+        }
+        else if (blockID == Blocks.GOLDEN_RAIL || blockID == Blocks.DETECTOR_RAIL || blockID == Blocks.ACTIVATOR_RAIL)
+        {
+            int power_bit = metadata&0x08;
+            int shape = metadata&0x07;
+            // minecart tracks
+            switch (dir)
+            {
+            case RuinsMod.DIR_EAST:
+                // flat tracks
+                if (shape == 0)
+                {
+                    return power_bit | 1;
+                }
+                if (shape == 1)
+                {
+                    return power_bit | 0;
+                }
+                // ascending tracks
+                if (shape == 2)
+                {
+                    return power_bit | 5;
+                }
+                if (shape == 3)
+                {
+                    return power_bit | 4;
+                }
+                if (shape == 4)
+                {
+                    return power_bit | 2;
+                }
+                if (shape == 5)
+                {
+                    return power_bit | 3;
+                }
+            case RuinsMod.DIR_SOUTH:
+                // flat tracks
+                if (shape == 0)
+                {
+                    return power_bit | 0;
+                }
+                if (shape == 1)
+                {
+                    return power_bit | 1;
+                }
+                // ascending tracks
+                if (shape == 2)
+                {
+                    return power_bit | 3;
+                }
+                if (shape == 3)
+                {
+                    return power_bit | 2;
+                }
+                if (shape == 4)
+                {
+                    return power_bit | 5;
+                }
+                if (shape == 5)
+                {
+                    return power_bit | 4;
+                }
+            case RuinsMod.DIR_WEST:
+                // flat tracks
+                if (shape == 0)
+                {
+                    return power_bit | 1;
+                }
+                if (shape == 1)
+                {
+                    return power_bit | 0;
+                }
+                // ascending tracks
+                if (shape == 2)
+                {
+                    return power_bit | 4;
+                }
+                if (shape == 3)
+                {
+                    return power_bit | 5;
+                }
+                if (shape == 4)
+                {
+                    return power_bit | 3;
+                }
+                if (shape == 5)
+                {
+                    return power_bit | 2;
                 }
             }
         }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -241,7 +241,7 @@ public class RuinTemplateRule
                         blockIDs[i] = r.tryFindingBlockOfName(data[0]);
                         if (blockIDs[i] == r.getAirBlock())
                         {
-                            if (!data[0].equals("air"))
+                            if (!isAir(data[0]))
                             {
                                 blockIDs[i] = null;
                                 if (!isKnownSpecialRule(blockStrings[i]))
@@ -292,7 +292,7 @@ public class RuinTemplateRule
                     else
                     {
                         blockIDs[i] = r.tryFindingBlockOfName(blockRules[i + 2]);
-                        if (blockIDs[i] == r.getAirBlock() && !data[0].equals("air"))
+                        if (blockIDs[i] == r.getAirBlock() && !isAir(blockRules[i + 2]))
                         {
                             // debugPrinter.println("Rule [" + rule + "] in
                             // template " + owner.getName()+" has something
@@ -2498,4 +2498,8 @@ public class RuinTemplateRule
         return CustomRotationMapping.getMapping(blockID, metadata, dir);
     }
 
+    private boolean isAir(String block)
+    {
+        return block.equals("air") || block.equals("minecraft:air");
+    }
 }


### PR DESCRIPTION
When used in a block rule, "minecraft:air" is flagged as a special block, then generates errors when it isn't recognized as such. The code is looking only for the explicit string "air" to define an air block; this modification allows it to treat "minecraft:air" as air, too.