### PR TITLE
command block rotation fix

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -1325,7 +1325,7 @@ public class RuinTemplateRule
              * regex pattern to find each coordinate triple with at least x and
              * z relative (with tilde), save xz numbers and y in groups
              */
-            final Pattern coordinates = Pattern.compile("~(-?\\d*) (~?-?\\d*) ~(-?\\d*)");
+            final Pattern coordinates = Pattern.compile("~(-\\d+|\\d*)[ \\t]+(~?-?\\d+|~)[ \\t]+~(-\\d+|\\d*)");
             final Matcher coordinateMatcher = coordinates.matcher(command);
             final StringBuffer stringBuffer = new StringBuffer();
             /* for each pattern match do */
@@ -1347,8 +1347,8 @@ public class RuinTemplateRule
                 }
                 else
                 {
-                    // case DIR_SOUTH, just swap x and z numbers
-                    coordinateMatcher.appendReplacement(stringBuffer, String.format("~%s %s ~%s", coordinateMatcher.group(3), coordinateMatcher.group(2), coordinateMatcher.group(1)));
+                    // case DIR_SOUTH, just negate x and z numbers
+                    coordinateMatcher.appendReplacement(stringBuffer, String.format("~%s %s ~%s", tryToInvert(coordinateMatcher.group(1)), coordinateMatcher.group(2), tryToInvert(coordinateMatcher.group(3))));
                 }
             }
             /*


### PR DESCRIPTION
This is the first of two rotation-related issues I ran across while I was overhauling block rotation. It's an existing bug in the code for rotation of command blocks--or, more specifically, the (attempted) rotation of the commands themselves within command blocks. The regex for extracting relative positions isn't quite right, and the SOUTH rotation is mathematically incorrect. Simple enough to fix.

**However**...I'd like to make a case for removing command rotation altogether. The real problems here run pretty deep. In order of increasing importance:
- **Lack of override mechanism:** What if I don't want to rotate a certain relative position? Maybe I want to spawn a rising sun altar east of my temple regardless of the temple's rotation. Can't do it.
- **False positives:** While the code does find and rotate relative positions in the command text, it also "rotates" any text that merely _looks like_ a relative position, such as might appear in sign text or custom names.
- **Incomplete rotation:** Rotating relative positions is only part of rotating a command. Target selectors dx, dz, ry, and rym are all sensitive to rotation. Teleport commands can specify horizontal rotation angle. NBT tags can contain rotation-dependent fields; for example, a spawned entity's yaw rotation and velocity vector. And so on. A partially rotated command might not function at all as intended.
- **Difficulty supporting other mods:** It's certainly possible to address the previous three points, but it would involve parsing and potentially processing every element in every vanilla command and every vanilla block and entity specification. Then there's the challenge of handling particular commands, blocks, and entities added by other mods--this mod's own testruin command, for instance, with a direction parameter that would have to be rotated. I don't think there's a general solution; supporting other mods would necessarily involve making mod-specific code changes to Ruins to get the job done right.

The bottom line is there's no practical or reliable way to rotate arbitrary commands correctly and completely. Rather than rotating some aspects and not others, yielding potential unexpected and undesirable results, I think it best not to try to rotate commands at all. That neatly sidesteps all the problems above and is, for what it's worth, the same tack followed by Minecraft's own structure block rotation. The RuinTemplateRule findAndRotateRelativeCommandBlockCoords() function should be eliminated, in my opinion.

But, if you think it should stay, this commit is a fix that needs to go in.