### PR TITLE
implement minimum distance from spawn parameter(s)

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
@@ -37,6 +37,8 @@ class FileHandler
 
     public float templateInstancesMinDistance = 75f;
     float anyRuinsMinDistance = 0f;
+    public int anySpawnMinDistance = 32;
+    public int anySpawnMaxDistance = Integer.MAX_VALUE;
     static final HashSet<Block> registeredTEBlocks = new HashSet<>();
 
     private int templateCount;
@@ -282,6 +284,18 @@ class FileHandler
                 anyRuinsMinDistance = Float.parseFloat(check[1]);
                 ruinsLog.println("anyRuinsMinDistance = " + anyRuinsMinDistance);
             }
+            if (check[0].equals("anySpawnMinDistance"))
+            {
+                final int value = Integer.parseInt(check[1]);
+                anySpawnMinDistance = value > 0 ? value : 0;
+                ruinsLog.println("anySpawnMinDistance = " + anySpawnMinDistance);
+            }
+            if (check[0].equals("anySpawnMaxDistance"))
+            {
+                final int value = Integer.parseInt(check[1]);
+                anySpawnMaxDistance = value > 0 ? value : Integer.MAX_VALUE;
+                ruinsLog.println("anySpawnMaxDistance = " + anySpawnMaxDistance);
+            }
             if (check[0].equals("allowedDimensions") && check.length > 1)
             {
                 String[] ints = check[1].split(",");
@@ -448,6 +462,9 @@ class FileHandler
         pw.println("templateInstancesMinDistance=256");
         pw.println("# minimum distance a template must have from any other template");
         pw.println("anyRuinsMinDistance=64");
+        pw.println("# min/max distances overworld templates can have from world spawn (0 = no limit)");
+        pw.println("anySpawnMinDistance=32");
+        pw.println("anySpawnMaxDistance=0");
         pw.println("# dimension IDs whitelisted for ruins spawning, add custom dimensions IDs here as needed");
         pw.println("allowedDimensions=0,1,-1");
         pw.println();

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -31,6 +31,8 @@ public class RuinTemplate
     private int height = 0, width = 0, length = 0, overhang = 0, weight = 1, embed = 0, randomOffMin = 0, randomOffMax = 0;
     private int leveling = 2, lbuffer = 0, w_off = 0, l_off = 0;
     public int uniqueMinDistance = 0;
+    public int spawnMinDistance = 0;
+    public int spawnMaxDistance = Integer.MAX_VALUE;
     private boolean preserveWater = false, preserveLava = false;
     private final VariantRuleset variantRuleset;
     private final ArrayList<RuinTemplateLayer> layers;
@@ -858,6 +860,16 @@ public class RuinTemplate
                 {
                     String[] check = line.split("=");
                     uniqueMinDistance = Integer.parseInt(check[1]);
+                }
+                else if (line.startsWith("spawnMinDistance"))
+                {
+                    final int value = Integer.parseInt(line.split("=")[1]);
+                    spawnMinDistance = value > 0 ? value : 0;
+                }
+                else if (line.startsWith("spawnMaxDistance"))
+                {
+                    final int value = Integer.parseInt(line.split("=")[1]);
+                    spawnMaxDistance = value > 0 ? value : Integer.MAX_VALUE;
                 }
                 else if (line.startsWith("preventRotation"))
                 {


### PR DESCRIPTION
This adds a new **spawnMinDistance** template parameter, which specifies the minimum distance (Chebyshev distance, in blocks, on the XZ plane) from the world spawn point an instance of that template can be naturally generated in the overworld. If absent, the value defaults to 0 (i.e., no minimum distance is enforced). There's also a new **spawnMaxDistance** parameter, because...why not? Its default value is (effectively) infinity, which is also the value it gets if one attempts to set it to 0 (i.e., no maximum distance is enforced).

There are two new config parameters as well: **anySpawnMinDistance** and **anySpawnMaxDistance**. These specify the minimum and maximum distance limits for ALL template instantiation in the overworld, and will override any less-restrictive template specifications. The default value of anySpawnMinDistance is 32; the default value of anySpawnMaxDistance is infinity (no maximum limit). This mimics the mod's original behavior.