### PR TITLE
DungeonTweeks Support

### DIFF
--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -1,5 +1,6 @@
 package atomicstryker.battletowers.common;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,12 +15,15 @@ import net.minecraft.entity.monster.EntitySpider;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.tileentity.TileEntityMobSpawner;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.eventhandler.Event;
 
 public class AS_WorldGenTower
 {
@@ -381,7 +385,11 @@ public class AS_WorldGenTower
                     	}
                     	else
                     	{
-                    		tileentitymobspawner.getSpawnerBaseLogic().setEntityId(new ResourceLocation("battletowers:" + towerChosen.getName() ));
+                    		try{
+                    		Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post").getConstructor(TileEntity.class,BlockPos.class,Random.class,ResourceLocation.class,World.class);
+                    		Event event = constructor.newInstance(tileentitymobspawner,tileentitymobspawner.getPos(),world.rand,new ResourceLocation("battletowers:" + towerChosen.getName() ),world);
+                    		MinecraftForge.EVENT_BUS.post(event);
+                    		}catch(Throwable t){t.printStackTrace();}
                     	}
                     }
 
@@ -395,7 +403,11 @@ public class AS_WorldGenTower
                     	}
                     	else
                     	{
-                    		tileentitymobspawner.getSpawnerBaseLogic().setEntityId(new ResourceLocation("battletowers:" + towerChosen.getName() ));
+                    		try{
+                        		Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post").getConstructor(TileEntity.class,BlockPos.class,Random.class,ResourceLocation.class,World.class);
+                        		Event event = constructor.newInstance(tileentitymobspawner,tileentitymobspawner.getPos(),world.rand,new ResourceLocation("battletowers:" + towerChosen.getName() ),world);
+                        		MinecraftForge.EVENT_BUS.post(event);
+                        	}catch(Throwable t){t.printStackTrace();}
                     	}
                     }
                 }

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -488,9 +488,7 @@ public class AS_WorldGenTower
 
             if (towerChosen != TowerTypes.Null)
             {
-                for (int l3 = 0; l3 < (floor * 4 + towerChosen.ordinal()) - 8 && !topFloor; l3++) // random hole
-                                                                                                  // 
-                                                                                                  // poker
+                for (int l3 = 0; l3 < (floor * 4 + towerChosen.ordinal()) - 8 && !topFloor; l3++) // random hole poker
                 {
                     int k4 = 5 - world.rand.nextInt(12);
                     int k5 = builderHeight + 5;

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -385,11 +385,16 @@ public class AS_WorldGenTower
                     	}
                     	else
                     	{
-                    		try{
-                    		Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post").getConstructor(TileEntity.class,BlockPos.class,Random.class,ResourceLocation.class,World.class);
-                    		Event event = constructor.newInstance(tileentitymobspawner,tileentitymobspawner.getPos(),world.rand,new ResourceLocation("battletowers:" + towerChosen.getName() ),world);
-                    		MinecraftForge.EVENT_BUS.post(event);
-                    		}catch(Throwable t){t.printStackTrace();}
+                    		try
+                    		{
+                    			Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post").getConstructor(TileEntity.class,BlockPos.class,Random.class,ResourceLocation.class,World.class);
+                    			Event event = constructor.newInstance(tileentitymobspawner,tileentitymobspawner.getPos(),world.rand,new ResourceLocation("battletowers:" + towerChosen.getName() ),world);
+                    			MinecraftForge.EVENT_BUS.post(event);
+                    		}
+                    		catch(Throwable t)
+                    		{
+                    			t.printStackTrace();
+                    		}
                     	}
                     }
 
@@ -403,11 +408,16 @@ public class AS_WorldGenTower
                     	}
                     	else
                     	{
-                    		try{
+                    		try
+                    		{
                         		Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post").getConstructor(TileEntity.class,BlockPos.class,Random.class,ResourceLocation.class,World.class);
                         		Event event = constructor.newInstance(tileentitymobspawner,tileentitymobspawner.getPos(),world.rand,new ResourceLocation("battletowers:" + towerChosen.getName() ),world);
                         		MinecraftForge.EVENT_BUS.post(event);
-                        	}catch(Throwable t){t.printStackTrace();}
+                        	}
+                    		catch(Throwable t)
+                    		{
+                    			t.printStackTrace();
+                    		}
                     	}
                     }
                 }

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -488,7 +488,9 @@ public class AS_WorldGenTower
 
             if (towerChosen != TowerTypes.Null)
             {
-                for (int l3 = 0; l3 < (floor * 4 + towerChosen.ordinal()) - 8 && !topFloor; l3++) // random hole poker
+                for (int l3 = 0; l3 < (floor * 4 + towerChosen.ordinal()) - 8 && !topFloor; l3++) // random hole
+                                                                                                  // 
+                                                                                                  // poker
                 {
                     int k4 = 5 - world.rand.nextInt(12);
                     int k5 = builderHeight + 5;

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -19,6 +19,7 @@ import net.minecraft.tileentity.TileEntityMobSpawner;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
 
 public class AS_WorldGenTower
 {
@@ -374,14 +375,28 @@ public class AS_WorldGenTower
                     TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) world.getTileEntity(new BlockPos(ix + 2, builderHeight + 6, kz + 2));
                     if (tileentitymobspawner != null)
                     {
-                        tileentitymobspawner.getSpawnerBaseLogic().setEntityId(getMobType(world.rand));
+                    	if(!Loader.isModLoaded("dungeontweaks"))
+                    	{
+                    		tileentitymobspawner.getSpawnerBaseLogic().setEntityId(getMobType(world.rand));
+                    	}
+                    	else
+                    	{
+                    		tileentitymobspawner.getSpawnerBaseLogic().setEntityId(new ResourceLocation("battletowers:" + towerChosen.getName() ));
+                    	}
                     }
 
                     world.setBlockState(new BlockPos(ix - 3, builderHeight + 6, kz + 2), Blocks.MOB_SPAWNER.getDefaultState());
                     tileentitymobspawner = (TileEntityMobSpawner) world.getTileEntity(new BlockPos(ix - 3, builderHeight + 6, kz + 2));
                     if (tileentitymobspawner != null)
                     {
-                        tileentitymobspawner.getSpawnerBaseLogic().setEntityId(getMobType(world.rand));
+                    	if(!Loader.isModLoaded("dungeontweaks"))
+                    	{
+                    		tileentitymobspawner.getSpawnerBaseLogic().setEntityId(getMobType(world.rand));
+                    	}
+                    	else
+                    	{
+                    		tileentitymobspawner.getSpawnerBaseLogic().setEntityId(new ResourceLocation("battletowers:" + towerChosen.getName() ));
+                    	}
                     }
                 }
                 else
@@ -562,28 +577,30 @@ public class AS_WorldGenTower
 
     public enum TowerTypes
     {
-        Null(Blocks.AIR, Blocks.AIR, Blocks.AIR, 0, Blocks.AIR),
-        CobbleStone(Blocks.COBBLESTONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 0, Blocks.STONE_STAIRS),
-        CobbleStoneMossy(Blocks.MOSSY_COBBLESTONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 0, Blocks.STONE_STAIRS),
-        SandStone(Blocks.SANDSTONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 1, Blocks.SANDSTONE_STAIRS),
-        Ice(Blocks.ICE, Blocks.AIR /* Blocks.GLOWSTONE */, Blocks.CLAY, 2, Blocks.OAK_STAIRS), // since when does glowstone melt ice
-        SmoothStone(Blocks.STONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 3, Blocks.STONE_STAIRS),
-        Netherrack(Blocks.NETHERRACK, Blocks.GLOWSTONE, Blocks.SOUL_SAND, 0, Blocks.NETHER_BRICK_STAIRS),
-        Jungle(Blocks.MOSSY_COBBLESTONE, Blocks.WEB, Blocks.DIRT, 0, Blocks.JUNGLE_STAIRS);
+        Null("null",Blocks.AIR, Blocks.AIR, Blocks.AIR, 0, Blocks.AIR),
+        CobbleStone("cobblestone",Blocks.COBBLESTONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 0, Blocks.STONE_STAIRS),
+        CobbleStoneMossy("cobblestonemossy",Blocks.MOSSY_COBBLESTONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 0, Blocks.STONE_STAIRS),
+        SandStone("sandstone",Blocks.SANDSTONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 1, Blocks.SANDSTONE_STAIRS),
+        Ice("ice",Blocks.ICE, Blocks.AIR /* Blocks.GLOWSTONE */, Blocks.CLAY, 2, Blocks.OAK_STAIRS), // since when does glowstone melt ice
+        SmoothStone("smoothstone",Blocks.STONE, Blocks.TORCH, Blocks.DOUBLE_STONE_SLAB, 3, Blocks.STONE_STAIRS),
+        Netherrack("netherrack",Blocks.NETHERRACK, Blocks.GLOWSTONE, Blocks.SOUL_SAND, 0, Blocks.NETHER_BRICK_STAIRS),
+        Jungle("jungle",Blocks.MOSSY_COBBLESTONE, Blocks.WEB, Blocks.DIRT, 0, Blocks.JUNGLE_STAIRS);
 
         private Block wallBlockID;
         private Block lightBlockID;
         private Block floorBlockID;
         private int floorBlockMetaData;
         private Block stairBlockID;
+        private String typeName;
 
-        TowerTypes(Block a, Block b, Block c, int d, Block e)
+        TowerTypes(String t,Block a, Block b, Block c, int d, Block e)
         {
             this.wallBlockID = a;
             this.lightBlockID = b;
             this.floorBlockID = c;
             this.floorBlockMetaData = d;
             this.stairBlockID = e;
+            this.typeName = t;
         }
 
         Block getWallBlockID()
@@ -609,6 +626,10 @@ public class AS_WorldGenTower
         Block getStairBlockID()
         {
             return stairBlockID;
+        }
+        public String getName()
+        {
+        	return this.typeName;
         }
     }
 


### PR DESCRIPTION
Yes this is more then I originally said It needed only a string change but, this class.forname event is because and only because, **you can retro gen battle towers after population of chunks**. I find that unacceptable so manual support is needed  to fire my custom events since chunk scanning isn't good enough. **Don't worry no dependencies needed.**

The mod is here this will allow dungeon tweaks to override all spawners and replace them for whatever the user configures:
https://minecraft.curseforge.com/projects/dungeon-tweaks