### PR TITLE
[Ruins] remove incorrect pos file path validation (fixes #194)

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
@@ -41,14 +41,7 @@ class RuinGenerator
         ruinsDataFile = new File(rh.saveFolder, fileName);
         ruinsDataFileWriting = new File(rh.saveFolder, fileName + "_writing");
 
-        if (ruinsDataFile.getAbsolutePath().contains(world.getWorldInfo().getWorldName()))
-        {
-            new LoadThread().start();
-        }
-        else
-        {
-            System.err.println("Ruins attempted to load invalid worldname " + world.getWorldInfo().getWorldName() + " posfile");
-        }
+        new LoadThread().start();
     }
 
     private class LoadThread extends Thread


### PR DESCRIPTION
An attempt is made to validate the position data file path by checking to make sure it contains the world name string. This validation fails on Windows servers if the world name is a path, though, since Windows uses backslashes to separate path elements instead of Java's native slashes. One solution would be to convert the path to a file system-neutral expression, but given how the path is generated, this validation is unnecessary and can be removed altogether, avoiding the separator issue completely.