### PR TITLE
[Ruins] remove embed distance from surface search

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -199,10 +199,10 @@ public class RuinTemplate
         }
 
         // guess the top Y coordinate of the structure box, for checking top to bottom
-        final int topYguess = y + height - embed + additionalYRangeChecked;
+        final int topYguess = y + height + additionalYRangeChecked;
 
         // set a lowest height value at which surface search is aborted
-        final int minimalCheckedY = y - height - embed - additionalYRangeChecked;
+        final int minimalCheckedY = y - height - additionalYRangeChecked;
 
         // surface heights of the proposed site, -1 means 'out of range, consider overhang'
         final int[][] heightMap = new int[xDim][zDim];


### PR DESCRIPTION
A template's embed_into_distance shouldn't factor into the search for an acceptable surface, since the structure is to be embedded into that surface _after_ one is found. Without this fix, structures are dragged down further than they should be, possibly low enough so that no surface can be found. This is the root cause behind Gillymoth's swamp structures not spawning when they should, as mentioned in [Forum post 4349](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4349).