### PR TITLE
[Ruins] fix leveling issues (fixes #192)

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
@@ -50,7 +50,7 @@ class CommandTestTemplate extends CommandBase
             {
                 if (parsedRuin != null)
                 {
-                    parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, xpos, ypos - 1, zpos, RuinsMod.DIR_NORTH, is_player);
+                    parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, xpos, ypos, zpos, RuinsMod.DIR_NORTH, is_player);
                     parsedRuin = null;
                 }
                 else
@@ -60,7 +60,7 @@ class CommandTestTemplate extends CommandBase
             }
             else
             {
-                tryBuild(sender, args, xpos, ypos - 1, zpos, is_player);
+                tryBuild(sender, args, xpos, ypos, zpos, is_player);
             }
         }
         else if (args.length >= 4)
@@ -73,7 +73,7 @@ class CommandTestTemplate extends CommandBase
                 }
                 else
                 {
-                    tryBuild(sender, args, (int) parseDouble(xpos, args[1], -30000000, 30000000, false), (int) parseDouble(ypos, args[2], -30000000, 30000000, false) - 1,
+                    tryBuild(sender, args, (int) parseDouble(xpos, args[1], -30000000, 30000000, false), (int) parseDouble(ypos, args[2], -30000000, 30000000, false),
                             (int) parseDouble(zpos, args[3], -30000000, 30000000, false), is_player);
                 }
             }
@@ -124,6 +124,7 @@ class CommandTestTemplate extends CommandBase
                             sender.sendMessage(new TextComponentTranslation("Could not find acceptable Y coordinate"));
                             return;
                         }
+                        ++y;
                     }
 
                     if (parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, x, y, z, rotation, is_player) >= 0)

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
@@ -381,7 +381,7 @@ class RuinGenerator
 
                 if (r.isAcceptableSurface(b))
                 {
-                    return y;
+                    return y + 1;
                 }
                 return -1;
             }
@@ -409,7 +409,7 @@ class RuinGenerator
                             {
                                 if (r.isAcceptableSurface(b))
                                 {
-                                    return y;
+                                    return y + 1;
                                 }
                                 return -1;
                             }
@@ -420,17 +420,18 @@ class RuinGenerator
             else
             {
                 // from the bottom. find the first air block from the floor
+                boolean accept = false;
                 for (int y = 0; y < WORLD_MAX_HEIGHT; y++)
                 {
                     BlockPos pos = new BlockPos(x, y, z);
                     final Block b = world.getBlockState(pos).getBlock();
                     if (!r.isIgnoredBlock(b, world, pos))
                     {
-                        if (r.isAcceptableSurface(b))
-                        {
-                            return y - 1;
-                        }
-                        return -1;
+                        accept = r.isAcceptableSurface(b);
+                    }
+                    else
+                    {
+                        return accept ? y : -1;
                     }
                 }
             }


### PR DESCRIPTION
Although Insane-96's issue #192 was closed as a presumed problem with templates, it actually points to some real problems related to leveling. Various functions throughout the mod disagreed as to whether the proposed Y-coordinate of a spawning site represented the base of the structure or the surface on which it was going to spawn (i.e., one block lower); as a result, structures occasionally spawned one block higher than they should. The leveling algorithm was not necessarily able to recover the surface fill block it needed after the Y-coordinate was massaged by checkArea(). The alternate nether Y-finding algorithm was outright broken. Blocks saved for the /undo function didn't account for leveling changes below the structure.

With these changes, I don't see structures "spawn in midair" any more (aside from the ones that are supposed to, of course). Leveling looks better all around, and /undo works. I didn't have to change any of the template files to fix the problems I saw.