### PR TITLE
[Ruins] reduce worldgen spam

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
@@ -187,9 +187,7 @@ class RuinGenerator
         {
             if (random.nextFloat() * 100 < fileHandler.chanceToSpawnNether)
             {
-                int xMod = (random.nextBoolean() ? random.nextInt(16) : 0 - random.nextInt(16));
-                int zMod = (random.nextBoolean() ? random.nextInt(16) : 0 - random.nextInt(16));
-                createBuilding(world, random, xBase + xMod, zBase + zMod, true);
+                createBuilding(world, random, xBase + random.nextInt(16), zBase + random.nextInt(16), true);
             }
         }
     }
@@ -219,13 +217,7 @@ class RuinGenerator
         RuinTemplate ruinTemplate = fileHandler.getTemplate(random, biomeID);
         if (ruinTemplate == null)
         {
-            biomeID = RuinsMod.BIOME_ANY;
-            ruinTemplate = fileHandler.getTemplate(random, biomeID);
-
-            if (ruinTemplate == null)
-            {
-                return;
-            }
+            return;
         }
         numTries++;
 


### PR DESCRIPTION
This addresses kellixon's Minecraft Forum [post 4382](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4382)...somewhat. Nether worldgen was sometimes basing its template instantiation on a block outside the chunk being generated. Template selection also had a sketchy fallback clause: choose a template specific to this biome (or possibly a generic template, depending on the **specific_biome** config setting), but if one isn't found, use a generic template _regardless of the config setting_. As a result, the workaround of setting **specific_hell=100** doesn't prevent generic template instantiation attempts as it should.

With these changes, the observed nether worldgen spam goes away if **specific_hell=100** is set, and is reduced if it remains set to the default value (75).

That's pretty much the best that can be done without a radical overhaul of the mod. There are ways to further mitigate the problem without implementing a complete solution, but I don't know it'd be worth the added complexity. As it is, Ruins is always going to trigger the "cascading worldgen" log occasionally as long as it supports structures of any reasonable size and features like **adjoining_template**. Though it's certainly possible to design pathological templates to cause runaway worldgen cascades, the warning is almost certainly just a benign annoyance and not a significant lag-inducing issue.