### PR TITLE
[Ruins] make /parseruin rule IDs line up

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
@@ -40,6 +40,7 @@ class FileHandler
     public int anySpawnMinDistance = 32;
     public int anySpawnMaxDistance = Integer.MAX_VALUE;
     public boolean enableStick = true;
+    public static boolean enableFixedWidthRuleIds = false;
     static final HashSet<Block> registeredTEBlocks = new HashSet<>();
 
     private int templateCount;
@@ -310,6 +311,10 @@ class FileHandler
                     allowedDimensions[i] = Integer.parseInt(ints[i]);
                 }
             }
+            else if (dimension == 0 && check[0].equals("enableFixedWidthRuleIds"))
+            {
+                enableFixedWidthRuleIds = Boolean.parseBoolean(check[1]);
+            }
             else if (check[0].equals("teblocks") && check.length > 1)
             {
                 String[] blocks = check[1].split(",");
@@ -468,6 +473,9 @@ class FileHandler
         pw.println("# dimension IDs whitelisted for ruins spawning, add custom dimensions IDs here as needed");
         pw.println("allowedDimensions=0,1,-1");
         pw.println();
+        pw.println("# make /parseruin rule IDs line up nicely in template files");
+        pw.println("# note: overworld (i.e., dimension 0) setting applies to all dimensions");
+        pw.println("enableFixedWidthRuleIds=false");
         pw.println("# tileentity blocks, those (nonvanilla)blocks which cannot function without storing their nbt data, full name as stick dictates, seperated by commata");
         pw.println("teblocks=");
         pw.println();

--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -499,10 +501,17 @@ class World2TemplateParser extends Thread
             pw.println("adjoining_template=");
             pw.println();
 
+            NumberFormat id_formatter = NumberFormat.getIntegerInstance();
+            if (FileHandler.enableFixedWidthRuleIds && id_formatter instanceof DecimalFormat)
+            {
+                int count = usedBlocks.size();
+                ((DecimalFormat) id_formatter).applyPattern(count < 10 ? "0" : count < 100 ? "00" : count < 1000 ? "000" : "0");
+            }
+
             int rulenum = 1;
             for (BlockData bd : usedBlocks)
             {
-                pw.println("rule" + rulenum + "=" + StringEscapeUtils.escapeJava(bd.toString()));
+                pw.println("rule" + id_formatter.format(rulenum) + "=" + StringEscapeUtils.escapeJava(bd.toString()));
                 rulenum++;
             }
 
@@ -521,7 +530,7 @@ class World2TemplateParser extends Thread
                          * since 'nothing' is not contained, it returns -1 + 1 =
                          * 0, which is the default preserveBlock rule
                          */
-                        pw.print(usedBlocks.indexOf(aLayer[j2]) + 1);
+                        pw.print(id_formatter.format(usedBlocks.indexOf(aLayer[j2]) + 1));
 
                         if (j < layer[0].length - 1)
                         {

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -523,3 +523,4 @@ a: setAccessible now true
 + constrain nether worldgen to chunk being decorated--reduces "cascading worldgen" log spam, bugfix
 + don't force generic template if no specific template available, bugfix
 + all parameters documented in default config and /parseruin template files
++ added config option to make /parseruin rules line up nicely


### PR DESCRIPTION
This change adds a new config parameter, **enableFixedWidthRuleIds**. If true, /parseruin left-zero-pads rule IDs to be all the same width, making layers nicely aligned regardless of number of relevant digits in the ID. The default is false to maintain original behavior.

This change is based on comments made by Gillymoth in [Minecraft Forum post 4408](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4408) and subsequent. It's an option because--as Gillymoth noted--there's currently a tradeoff between readability and performance due to the use of /testruin during worldgen. (Hopefully, there'll be an alternative to /testruin soon that renders this tradeoff moot--spoiler alert!)

One peculiarity--only the value of **enableFixedWidthRuleIds** for dimension 0 is used, and it's used for all dimensions. Values specified for all other dimensions are ignored. This is noted in comments in the default ruins.txt config file. It's not without precedent; the **teblocks** config parameter is also static, and the values across all dimension settings are combined into one grand list for all dimensions. Some day, there might be a differentiation between global config parameters like these and per-dimension ones...but not today.

Note this only affects new template files generated by /parseruin. It has no effect whatsoever on the _reading_ of templates, so old templates will still be read in just fine, and new templates generated with this option can be read by earlier versions of ruins without this change.