### PR TITLE
[Ruins] generalize comma hiding for rule parsing

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -1,7 +1,6 @@
 package atomicstryker.ruins.common;
 
 import java.io.PrintWriter;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -80,7 +79,7 @@ public class RuinTemplateRule
         owner = r;
         excessiveDebugging = debug;
 
-        Lumper lumper = new Lumper(owner, excessiveDebugging ? debugPrinter : null);
+        RuinTextLumper lumper = new RuinTextLumper(owner, excessiveDebugging ? debugPrinter : null);
         rule = lumper.lump(rule);
 
         String[] blockRules = rule.split(",");
@@ -609,7 +608,7 @@ public class RuinTemplateRule
         }
         else if (dataString.startsWith("IInventory;"))
         {
-            Lumper lumper = new Lumper(owner, excessiveDebugging ? debugPrinter : null);
+            RuinTextLumper lumper = new RuinTextLumper(owner, excessiveDebugging ? debugPrinter : null);
             String dataWithoutNBT = lumper.lump(dataString);
             String[] s = dataWithoutNBT.split(";");
             Object o = tryFindingObject(s[1]);
@@ -1046,7 +1045,7 @@ public class RuinTemplateRule
     }
 
     @SuppressWarnings("deprecation")
-    private void addIInventoryBlock(World world, Random random, int x, int y, int z, Block block, String itemDataWithoutNBT, Lumper lumper, int metadata, int direction)
+    private void addIInventoryBlock(World world, Random random, int x, int y, int z, Block block, String itemDataWithoutNBT, RuinTextLumper lumper, int metadata, int direction)
     {
         TileEntity te = realizeBlock(world, x, y, z, block, metadata, direction);
         if (te instanceof IInventory)
@@ -1076,7 +1075,7 @@ public class RuinTemplateRule
         }
     }
 
-    private void handleIInventory(IInventory inv, String itemDataWithoutNBT, Lumper lumper)
+    private void handleIInventory(IInventory inv, String itemDataWithoutNBT, RuinTextLumper lumper)
     {
         // example string:
         // minecraft:stone#1#4#0+minecraft:written_book#NBT1#0#1+minecraft:chest#1#0#2
@@ -1469,158 +1468,6 @@ public class RuinTemplateRule
         {
             entity.rotate(getDirectionalRotation(direction));
             entity.markDirty();
-        }
-    }
-
-    // utility for hiding troublesome commas to simplify rule parsing
-    private static class Lumper
-    {
-        private RuinTemplate template_;
-        private PrintWriter log_;
-        private List<String> lumps_;
-
-        // create new lumper
-        public Lumper(RuinTemplate template, PrintWriter log)
-        {
-            template_ = template;
-            log_ = log;
-            lumps_ = new ArrayList<>();
-        }
-
-        private static final Pattern LUMP_PATTERN = Pattern.compile("(\\{)|\\[[^]]*+]|Lu\\d++mP");
-        private static final Pattern BRACED_LUMP_PATTERN = Pattern.compile("(})|(\")|\\{");
-        private static final Pattern QUOTED_LUMP_PATTERN = Pattern.compile("(\")|\\\\.");
-
-        // replace problematic text ("lumps") with Lu#mP placeholders:
-        // 1) {text in {possibly nested} braces}, such as NBT tags
-        // 2) [text in brackets], such as block state properties
-        // 3) unlikely text that happens to look like a placeholder
-        // note: all previous placeholder data is discarded
-        public String lump(String input)
-        {
-            lumps_.clear();
-            StringBuilder output = new StringBuilder();
-            int start = 0;
-            final int end = input.length();
-            Matcher matcher = LUMP_PATTERN.matcher(input);
-            while (start < end)
-            {
-                if (matcher.find(start))
-                {
-                    int extent = matcher.end();
-                    if (matcher.group(1) != null)
-                    {
-                        extent = extendNestedLump(BRACED_LUMP_PATTERN, input, extent, end);
-                    }
-                    if (extent >= start)
-                    {
-                        output.append(input.substring(start, matcher.start())).append("Lu").append(lumps_.size()).append("mP");
-                        String lump = input.substring(matcher.start(), extent);
-                        lumps_.add(lump);
-                        if (log_ != null)
-                        {
-                            log_.println("template " + template_.getName() + " contains lump: " + lump);
-                        }
-                        start = extent;
-                    }
-                    else
-                    {
-                        System.err.println("Unbalanced nesting in Ruins template " + template_.getName() + ", offending rule: " + input);
-                        output.append(input.substring(start));
-                        break;
-                    }
-                }
-                else
-                {
-                    output.append(input.substring(start));
-                    break;
-                }
-            }
-            return output.toString();
-        }
-
-        // find end position of entire (possibly) nested lump
-        private int extendNestedLump(Pattern pattern, String input, int start, int end)
-        {
-            int depth = 0;
-            Matcher matcher = pattern.matcher(input);
-            while (start < end)
-            {
-                if (matcher.find(start))
-                {
-                    start = matcher.end();
-                    if (matcher.group(1) != null)
-                    {
-                        if (--depth < 0)
-                        {
-                            return start;
-                        }
-                    }
-                    else if (matcher.group(2) != null)
-                    {
-                        if ((start = extendQuotedLump(input, start, end)) < 0)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        ++depth;
-                    }
-                }
-                else
-                {
-                    break;
-                }
-            }
-            return -1;
-        }
-
-        // find end position of entire quoted lump
-        private int extendQuotedLump(String input, int start, int end)
-        {
-            Matcher matcher = QUOTED_LUMP_PATTERN.matcher(input);
-            while (start < end)
-            {
-                if (matcher.find(start))
-                {
-                    start = matcher.end();
-                    if (matcher.group(1) != null)
-                    {
-                        return start;
-                    }
-                }
-                else
-                {
-                    break;
-                }
-            }
-            return -1;
-        }
-
-        private static final Pattern UNLUMP_PATTERN = Pattern.compile("Lu(\\d++)mP");
-
-        // replace lump placeholders with original text
-        public String unlump(String input)
-        {
-            StringBuilder output = new StringBuilder();
-            int start = 0;
-            final int end = input.length();
-            Matcher matcher = UNLUMP_PATTERN.matcher(input);
-            while (start < end)
-            {
-                if (matcher.find())
-                {
-                    output.append(input.substring(start, matcher.start())).append(lumps_.get(Integer.parseInt(matcher.group(1))));
-                    start = matcher.end();
-                }
-                else
-                {
-                    output.append(input.substring(start));
-                    break;
-                }
-            }
-            return output.toString();
         }
     }
 }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTextLumper.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTextLumper.java
@@ -1,0 +1,159 @@
+package atomicstryker.ruins.common;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+// utility for hiding troublesome commas to simplify rule parsing
+class RuinTextLumper
+{
+    private RuinTemplate template_;
+    private PrintWriter log_;
+    private List<String> lumps_;
+
+    // create new lumper
+    public RuinTextLumper(RuinTemplate template, PrintWriter log)
+    {
+        template_ = template;
+        log_ = log;
+        lumps_ = new ArrayList<>();
+    }
+
+    private static final Pattern LUMP_PATTERN = Pattern.compile("(\\{)|\\[[^]]*+]|Lu\\d++mP");
+    private static final Pattern BRACED_LUMP_PATTERN = Pattern.compile("(})|(\")|\\{");
+    private static final Pattern QUOTED_LUMP_PATTERN = Pattern.compile("(\")|\\\\.");
+
+    // replace problematic text ("lumps") with Lu#mP placeholders:
+    // 1) {text in {possibly nested} braces}, such as NBT tags
+    // 2) [text in brackets], such as block state properties
+    // 3) unlikely text that happens to look like a placeholder
+    // note: all previous placeholder data is discarded
+    public String lump(String input)
+    {
+        lumps_.clear();
+        StringBuilder output = new StringBuilder();
+        int start = 0;
+        final int end = input.length();
+        Matcher matcher = LUMP_PATTERN.matcher(input);
+        while (start < end)
+        {
+            if (matcher.find(start))
+            {
+                int extent = matcher.end();
+                if (matcher.group(1) != null)
+                {
+                    extent = extendNestedLump(BRACED_LUMP_PATTERN, input, extent, end);
+                }
+                if (extent >= start)
+                {
+                    output.append(input.substring(start, matcher.start())).append("Lu").append(lumps_.size()).append("mP");
+                    String lump = input.substring(matcher.start(), extent);
+                    lumps_.add(lump);
+                    if (log_ != null)
+                    {
+                        log_.println("template " + template_.getName() + " contains lump: " + lump);
+                    }
+                    start = extent;
+                }
+                else
+                {
+                    System.err.println("Unbalanced nesting in Ruins template " + template_.getName() + ", offending rule: " + input);
+                    output.append(input.substring(start));
+                    break;
+                }
+            }
+            else
+            {
+                output.append(input.substring(start));
+                break;
+            }
+        }
+        return output.toString();
+    }
+
+    // find end position of entire (possibly) nested lump
+    private int extendNestedLump(Pattern pattern, String input, int start, int end)
+    {
+        int depth = 0;
+        Matcher matcher = pattern.matcher(input);
+        while (start < end)
+        {
+            if (matcher.find(start))
+            {
+                start = matcher.end();
+                if (matcher.group(1) != null)
+                {
+                    if (--depth < 0)
+                    {
+                        return start;
+                    }
+                }
+                else if (matcher.group(2) != null)
+                {
+                    if ((start = extendQuotedLump(input, start, end)) < 0)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    ++depth;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+        return -1;
+    }
+
+    // find end position of entire quoted lump
+    private int extendQuotedLump(String input, int start, int end)
+    {
+        Matcher matcher = QUOTED_LUMP_PATTERN.matcher(input);
+        while (start < end)
+        {
+            if (matcher.find(start))
+            {
+                start = matcher.end();
+                if (matcher.group(1) != null)
+                {
+                    return start;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+        return -1;
+    }
+
+    private static final Pattern UNLUMP_PATTERN = Pattern.compile("Lu(\\d++)mP");
+
+    // replace lump placeholders with original text
+    public String unlump(String input)
+    {
+        StringBuilder output = new StringBuilder();
+        int start = 0;
+        final int end = input.length();
+        Matcher matcher = UNLUMP_PATTERN.matcher(input);
+        while (start < end)
+        {
+            if (matcher.find())
+            {
+                output.append(input.substring(start, matcher.start())).append(lumps_.get(Integer.parseInt(matcher.group(1))));
+                start = matcher.end();
+            }
+            else
+            {
+                output.append(input.substring(start));
+                break;
+            }
+        }
+        return output.toString();
+    }
+}

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -524,3 +524,5 @@ a: setAccessible now true
 + don't force generic template if no specific template available, bugfix
 + all parameters documented in default config and /parseruin template files
 + added config option to make /parseruin rules line up nicely
++ properly handle quoted braces in {NBT tag rule text}, bugfix
++ hide commas in [bracketed rule text], 1.13 prep


### PR DESCRIPTION
Ruins currently has a method for substituting {brace-delimited NBT tags} in a rule with placeholders so as to hide commas that'd screw up its simple split-on-comma parsing, and another to restore the original text. Going forward, [bracket-delimited block state properties] may also contain commas, so this pull request anticipates upcoming changes by replacing the NBT tag substitution and restoration methods with a more general-purpose utility. It also addresses some shortcomings in the current code, such as its failure to properly account for quoted strings containing "false" delimiter characters and placeholder-like text which could confound the restoration process.

While this pull is primarily intended as part of the preparation for Minecraft 1.13, it isn't at all 1.13-specific and works just fine in 1.12.