### PR TITLE
[Ruins] biomes to spawn in by type

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -466,6 +466,15 @@ class World2TemplateParser extends Thread
             pw.println("# biome corresponding to directory is always assumed, listed or not");
             pw.println("# generic templates should leave this list empty");
             pw.println("biomesToSpawnIn=");
+            pw.println("# list of biome types (or ALL) in which this template may spawn");
+            pw.println("# this is in addition to those explicitly listed as biomesToSpawnIn");
+            pw.println("# generic templates should leave this list empty");
+            pw.println("biomeTypesToSpawnIn=");
+            pw.println("# exclusion list of biomes and biome types");
+            pw.println("# takes precedence over biomeTypesToSpawnIn, but NOT biomesToSpawnIn");
+            pw.println("# both should be empty if biomeTypesToSpawnIn is empty");
+            pw.println("biomesToNotSpawnIn=");
+            pw.println("biomeTypesToNotSpawnIn=");
             pw.println("# depth template is pushed down into the surface when built");
             pw.println("# offset is min/max range of random additional bury depth");
             pw.println("embed_into_distance=" + yPadding);

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -524,3 +524,4 @@ a: setAccessible now true
 + don't force generic template if no specific template available, bugfix
 + all parameters documented in default config and /parseruin template files
 + added config option to make /parseruin rules line up nicely
++ templates can now specify biomes to spawn in by type

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -151,6 +151,25 @@
 # If the space between max and min distances is too narrow (namely, less than
 # the length and width of the template), no instances can naturally generate.
 #
+# Ruins 17.2 adds three new optional variables:
+#
+# biomeTypesToSpawnIn=<name1>,<name2>,<name3>...
+# Adds the Template being loaded (regardless which folder it is in) to every Ruins Biome
+# found in the Minecraft Biomelist for which at least one <namex> is among the Biome's types.
+# Case insensitive. The special type ALL may be specified to include all Biomes.
+# example: biomeTypesToSpawnIn=dry,cold
+# Optional. May be used in addition to, or instead of, biomesToSpawnIn.
+#
+# biomesToNotSpawnIn=<name1>,<name2>,<name3>...
+# biomeTypesToNotSpawnIn=<name1>,<name2>,<name3>...
+# Excludes the Template being loaded from every Ruins Biome found in the Minecraft Biomelist
+# with the specified name or type, respectively. Case insensitive. Note these take precedence
+# over biomeTypesToSpawnIn, but do not inhibit Biomes listed as biomesToSpawnIn, nor the
+# Biome associated with the Template's folder.
+# example: biomesToNotSpawnIn=ice_flats,ice_mountains
+# example: biomeTypesToNotSpawnIn=spooky,rare
+# Optional. Only relevant if biomeTypesToSpawnIn list is not empty.
+#
 
 weight=5
 embed_into_distance=1


### PR DESCRIPTION
This change allows a template to alternatively (or additionally) specify the biomes in which it can be instantiated by Forge's BiomeDictionary.Type instead of name. So, instead of explicitly listing all forest-like biomes...
**biomesToSpawnIn=forest,birch_forest,taiga,roofed_forest,forest_hills,yada,yada,yada**
...one can simply specify one or more types...
**biomeTypesToSpawnIn=forest**
This will also catch any biome--vanilla or modded--matching at least one of the specified types. The special type "all" can be used to indicate _all_ biomes, regardless of type (even including biomes with no type).

To further fine-tune the list of eligible biomes, the new variables **biomesToNotSpawnIn** and **biomeTypesToNotSpawnIn** are available, allowing the exclusion of biomes by name or type, respectively. Note these only affect biomes included via **biomeTypesToSpawnIn**; biomes listed as **biomesToSpawnIn** are _always_ candidates for spawing--as is the biome corresponding to the template's folder, of course--even if they appear on the exclusion lists. Here's a more comprehensive example:
**biomesToSpawnIn=mushroom_island
biomeTypesToSpawnIn=forest,jungle
biomesToNotSpawnIn=birch_forest
biomeTypesToNotSpawnIn=hills,mountain**
A template with these variable settings can spawn on mushroom islands (but not mushroom island shores, a different biome) and in any biome that's either a forest or jungle type (or both), _unless_ it's also a birch forest, or a hill or mountain type. Whew!

I expect in the real world, the typical case will be to just specify **biomeTypesToSpawnIn** to apply a particular "theme" to a template. This avoids the need for lengthy **biomesToSpawnIn** lists, command block proxies and template duplication, and the omission of unanticipated biomes added by other mods.

The default biome types are (currently): hot, cold, sparse, dense, wet, dry, savanna, coniferous, jungle, spooky, dead, lush, nether, end, mushroom, magical, rare, ocean, river, water, mesa, forest, plains, mountain, hills, swamp, sandy, snowy, wasteland, beach, and void. As mentioned above, an additional special type--all--may be used for **biomeTypesToSpawnIn**. Mods can also create new biome types, so this list isn't necessarily complete, but Ruins will fully support modded types as well.