### PR TITLE
[Ruins] add simple boolean operations to biomeTypesToSpawnIn

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinBiomeTypeCriteria.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinBiomeTypeCriteria.java
@@ -1,0 +1,123 @@
+package atomicstryker.ruins.common;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraftforge.common.BiomeDictionary;
+
+// a biome type criteria collection against which biomes are checked
+// as to whether or not they satisfy at least one of the specified
+// conditions
+class RuinBiomeTypeCriteria
+{
+    private RuinTemplate template_;
+    private PrintWriter log_;
+
+    // a biome satisfies a particular criterion if it is assigned
+    // ALL the included types and NONE of the excluded ones
+    private static class Criterion
+    {
+        private RuinTemplate template_;
+        private PrintWriter log_;
+
+        private Set<String> included_;
+        private Set<String> excluded_;
+
+        private static final Pattern SPEC_PATTERN = Pattern.compile("(?:\\+|(-))?+([^+-]++)");
+
+        // parse given specification string into a new criterion
+        public Criterion(RuinTemplate template, PrintWriter log, String spec)
+        {
+            template_ = template;
+            log_ = log;
+            if (log_ != null)
+            {
+                log_.printf("adding new criterion: spec=\"%s\"\n", spec);
+            }
+            included_ = new HashSet<>();
+            excluded_ = new HashSet<>();
+            Matcher matcher = SPEC_PATTERN.matcher(spec);
+            int start = 0;
+            final int end = spec.length();
+            while (start < end)
+            {
+                if (matcher.find(start))
+                {
+                    if (matcher.start() != start)
+                    {
+                        System.err.printf("invalid use of operator(s) in biome type list; template=\"%s\", list element=\"%s\"\n",
+                                template_.getName(), spec.substring(start, matcher.end()));
+                    }
+                    if (log_ != null)
+                    {
+                        log_.printf("%s biome type %s\n", (matcher.group(1) != null ? "excluding" : "including"), matcher.group(2));
+                    }
+                    (matcher.group(1) != null ? excluded_ : included_).add(matcher.group(2));
+                    start = matcher.end();
+                }
+                else
+                {
+                    System.err.printf("cannot parse text in biome type list; template=\"%s\", text=\"%s\"\n",
+                            template_.getName(), spec.substring(start));
+                    break;
+                }
+            }
+            if (included_.isEmpty() && !excluded_.isEmpty())
+            {
+                if (log_ != null)
+                {
+                    log_.printf("including biome type ALL (implicit)\n");
+                }
+                included_.add("ALL");
+            }
+        }
+
+        // does the given set of biome type names satisfy this criterion?
+        public boolean satisfiedBy(Set<String> type_names)
+        {
+            return Collections.disjoint(type_names, excluded_) && type_names.containsAll(included_);
+        }
+    }
+
+    private List<Criterion> criteria_;
+
+    // create a new set of criteria
+    public RuinBiomeTypeCriteria(RuinTemplate template, PrintWriter log)
+    {
+        template_ = template;
+        log_ = log;
+        criteria_ = new ArrayList<>();
+    }
+
+    // parse given specification string into criterion objects
+    public void addCriteria(String specs)
+    {
+        for (String spec : specs.toUpperCase().split(","))
+        {
+            criteria_.add(new Criterion(template_, log_, spec));
+        }
+    }
+
+    // does the given biome satisfy all criteria?
+    public boolean satisfiedBy(Biome biome)
+    {
+        Set<String> type_names = new HashSet<>();
+        BiomeDictionary.getTypes(biome).forEach(type -> type_names.add(type.getName().toUpperCase()));
+        type_names.add("ALL");
+        for (Criterion criterion : criteria_)
+        {
+            if (criterion.satisfiedBy(type_names))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -525,3 +525,4 @@ a: setAccessible now true
 + all parameters documented in default config and /parseruin template files
 + added config option to make /parseruin rules line up nicely
 + templates can now specify biomes to spawn in by type
++ enhance biomeTypesToSpawnIn with simple boolean operations

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -170,6 +170,16 @@
 # example: biomeTypesToNotSpawnIn=spooky,rare
 # Optional. Only relevant if biomeTypesToSpawnIn list is not empty.
 #
+# In both the biomeTypesToSpawnIn and biomeTypesToNotSpawnIn lists, some rudimentary boolean
+# operations are allowed by concatenating multiple type names separated by + (and) or - (and
+# not). So, for example:
+# biomeTypesToSpawnIn=forest-cold,jungle+hills
+# This adds the template to all biomes that are of type forest AND NOT cold, or are of both
+# jungle AND hills. Order doesn't matter, so the following is equivalent:
+# biomeTypesToSpawnIn=hills+jungle,-cold+forest
+# If all the types are exclusions, an implicit ALL is added. Thus, "-nether-end" is the same
+# as "all-nether-end" (i.e., any biome that isn't of type nether or end).
+#
 
 weight=5
 embed_into_distance=1


### PR DESCRIPTION
Stupid ENTER key jumped right out in front of me before I could type a comment! I swear!

This change addresses MentalMouse's comments on pull request #213 by allowing **biomeTypesToSpawnIn** to accept rudimentary boolean operations in addition to just plain type names. Type names still work as before--they're essentially degenerate cases. But now you can concatenate multiple type names together, separated by + (AND) operator, to specify a biome that has _all_ those types. So, if you want to spawn only in cold forests or snowy mountains, you can set:
**biomeTypesToSpawnIn=cold+forest,snowy+mountain**
This means in order to be a spawn candidate, a biome must be both cold AND forest types, or both snowy AND mountain types. There's also a - (AND NOT) operator:
**biomeTypesToSpawnIn=hot+dry-nether**
This means a biome must be both hot AND dry, AND NOT nether. These operators may also be used in specifying **biomeTypesToNotSpawnIn**, for those who can follow the twisty logic.
 