### PR TITLE
[Ruins] eliminate pesky ALL biome pseudotype

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinBiomeTypeCriteria.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinBiomeTypeCriteria.java
@@ -69,13 +69,9 @@ class RuinBiomeTypeCriteria
                     break;
                 }
             }
-            if (included_.isEmpty() && !excluded_.isEmpty())
+            if (included_.isEmpty() && log_ != null)
             {
-                if (log_ != null)
-                {
-                    log_.printf("including biome type ALL (implicit)\n");
-                }
-                included_.add("ALL");
+                log_.printf("including all other biome types (implicit)\n");
             }
         }
 
@@ -105,12 +101,11 @@ class RuinBiomeTypeCriteria
         }
     }
 
-    // does the given biome satisfy all criteria?
+    // does the given biome satisfy at least one criterion?
     public boolean satisfiedBy(Biome biome)
     {
         Set<String> type_names = new HashSet<>();
         BiomeDictionary.getTypes(biome).forEach(type -> type_names.add(type.getName().toUpperCase()));
-        type_names.add("ALL");
         for (Criterion criterion : criteria_)
         {
             if (criterion.satisfiedBy(type_names))
@@ -119,5 +114,11 @@ class RuinBiomeTypeCriteria
             }
         }
         return false;
+    }
+
+    // are there any criteria?
+    public boolean isEmpty()
+    {
+        return criteria_.isEmpty();
     }
 }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -987,13 +987,13 @@ public class RuinTemplate
         // 2) biomes with at least one type listed as a biomeTypesToSpawnIn are added, UNLESS...
         // 2a) ...the biome is listed as a biomesToNotSpawnIn, or
         // 2b) ...the biome has at least one type listed as a BiomeTypesToNotSpawnIn
-        // note: special type ALL may be used to specify all biomes
+        final boolean consider_types = !excluded_biomes.isEmpty() || !included_biome_types.isEmpty() || !excluded_biome_types.isEmpty();
         for (Iterator<Biome> biome_iter = Biome.REGISTRY.iterator(); biome_iter.hasNext(); )
         {
             Biome biome = biome_iter.next();
             String biome_name = biome.getRegistryName().getResourcePath();
-            if (!biomes.contains(biome_name) && (included_biomes.contains(biome_name) || !excluded_biomes.contains(biome_name) &&
-                    included_biome_types.satisfiedBy(biome) && !excluded_biome_types.satisfiedBy(biome)))
+            if (!biomes.contains(biome_name) && (included_biomes.contains(biome_name) || consider_types && !excluded_biomes.contains(biome_name) &&
+                    (included_biome_types.isEmpty() || included_biome_types.satisfiedBy(biome)) && !excluded_biome_types.satisfiedBy(biome)))
             {
                 biomes.add(biome_name);
             }

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -156,7 +156,7 @@
 # biomeTypesToSpawnIn=<name1>,<name2>,<name3>...
 # Adds the Template being loaded (regardless which folder it is in) to every Ruins Biome
 # found in the Minecraft Biomelist for which at least one <namex> is among the Biome's types.
-# Case insensitive. The special type ALL may be specified to include all Biomes.
+# Case insensitive.
 # example: biomeTypesToSpawnIn=dry,cold
 # Optional. May be used in addition to, or instead of, biomesToSpawnIn.
 #
@@ -168,7 +168,8 @@
 # Biome associated with the Template's folder.
 # example: biomesToNotSpawnIn=ice_flats,ice_mountains
 # example: biomeTypesToNotSpawnIn=spooky,rare
-# Optional. Only relevant if biomeTypesToSpawnIn list is not empty.
+# Optional. If biomeTypesToSpawnIn list is empty and one or both of these are not, all
+# non-excluded biomes are added. If all three lists are empty, only biomesToSpawnIn applies.
 #
 # In both the biomeTypesToSpawnIn and biomeTypesToNotSpawnIn lists, some rudimentary boolean
 # operations are allowed by concatenating multiple type names separated by + (and) or - (and
@@ -177,8 +178,8 @@
 # This adds the template to all biomes that are of type forest AND NOT cold, or are of both
 # jungle AND hills. Order doesn't matter, so the following is equivalent:
 # biomeTypesToSpawnIn=hills+jungle,-cold+forest
-# If all the types are exclusions, an implicit ALL is added. Thus, "-nether-end" is the same
-# as "all-nether-end" (i.e., any biome that isn't of type nether or end).
+# If all the types are exclusions, all non-excluded types are added. Thus, "-nether-end"
+# means every biome that isn't of type nether or end.
 #
 
 weight=5


### PR DESCRIPTION
Okay, last one on this, I promise. It occurs to me (late) that I don't really need the fake ALL biome type if I make everything consistent with the precedent already set by variables **acceptable_target_blocks** and **unacceptable_target_blocks**:
- If the inclusion list (in this case, **acceptable_target_blocks**) has one or more entries, only those items are included. If the inclusion list is empty, _all_ items are included.
- If the exclusion list (**unacceptable_target_blocks**) has one or more entries, only those items are excluded. If the exclusion list is empty, _no_ items are excluded.

The final list of items (target blocks, here) consists of all those both included AND not excluded.

So, if I apply this model to my new **biomeTypesToSpawnIn** crap:

- I don't need an ALL type in the boolean expressions. If all the terms are exclusion terms, that's the empty inclusion case; as above, _all_ items are included. The final list of biome types consists of all those both included AND not excluded.
- I don't need an ALL type for **biomeTypesToSpawnIn** if you want to just start with everything and then do exclusions via **biomesToNotSpawnIn** and **biomeTypesToNotSpawnIn**. If **biomeTypesToSpawnIn** is blank, that's the empty inclusion case again.

That leaves one special case: what happens if all three of the new lists are empty? Interpreting that as meaning every biome is a spawn candidate seems wrong, especially since empty lists are the defaults. Instead, I interpret that as meaning the spawn-by-biome-type feature is disabled, and the template simply uses **biomesToSpawnIn**, just like old times.

No bug fixes here (aside from correcting a comment), so if you'd rather keep the feature the way it is, ALL and all, this pull can be rejected without issue. I think it does make for more consistent behavior, though, and is marginally simpler. Kind of. If you squint.