### PR TITLE
[Ruins] templates can declare required/prohibited mods

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
@@ -141,6 +141,10 @@ class CommandTestTemplate extends CommandBase
                     sender.sendMessage(new TextComponentTranslation("Could not parse Ruin of file " + file));
                 }
             }
+            catch (RuinTemplate.RequiredModNotActiveException | RuinTemplate.ProhibitedModActiveException e)
+            {
+                sender.sendMessage(new TextComponentTranslation(e.getMessage()));
+            }
             catch (Exception e)
             {
                 e.printStackTrace();

--- a/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
@@ -141,7 +141,7 @@ class CommandTestTemplate extends CommandBase
                     sender.sendMessage(new TextComponentTranslation("Could not parse Ruin of file " + file));
                 }
             }
-            catch (RuinTemplate.RequiredModNotActiveException | RuinTemplate.ProhibitedModActiveException e)
+            catch (RuinTemplate.IncompatibleModException e)
             {
                 sender.sendMessage(new TextComponentTranslation(e.getMessage()));
             }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
@@ -393,7 +393,7 @@ class FileHandler
                     // pw.println("Successfully loaded template " + f.getName() + " with weight " + r.getWeight() + ".");
                     templateCount++;
                 }
-                catch (RuinTemplate.RequiredModNotActiveException | RuinTemplate.ProhibitedModActiveException e)
+                catch (RuinTemplate.IncompatibleModException e)
                 {
                     pw.println(e.getMessage());
                 }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
@@ -393,6 +393,10 @@ class FileHandler
                     // pw.println("Successfully loaded template " + f.getName() + " with weight " + r.getWeight() + ".");
                     templateCount++;
                 }
+                catch (RuinTemplate.RequiredModNotActiveException | RuinTemplate.ProhibitedModActiveException e)
+                {
+                    pw.println(e.getMessage());
+                }
                 catch (Exception e)
                 {
                     pw.println();

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -979,7 +979,7 @@ public class RuinTemplate
                                 {
                                     debugPrinter.printf("template [%s]: required mod [%s] not active\n", name, mod);
                                 }
-                                throw new RequiredModNotActiveException(name, mod);
+                                throw new IncompatibleModException(true, name, mod);
                             }
                         }
                     }
@@ -997,7 +997,7 @@ public class RuinTemplate
                                 {
                                     debugPrinter.printf("template [%s]: prohibited mod [%s] active\n", name, mod);
                                 }
-                                throw new ProhibitedModActiveException(name, mod);
+                                throw new IncompatibleModException(false, name, mod);
                             }
                         }
                     }
@@ -1018,7 +1018,7 @@ public class RuinTemplate
                             {
                                 adjTempl = new RuinTemplate(debugPrinter, file.getCanonicalPath(), file.getName(), false);
                             }
-                            catch (RequiredModNotActiveException | ProhibitedModActiveException e)
+                            catch (IncompatibleModException e)
                             {
                                 if (debugging)
                                 {
@@ -1311,33 +1311,14 @@ public class RuinTemplate
         }
     }
 
-    public static class ClassException extends RuntimeException
-    {
-        private static final long serialVersionUID = -7630819126112904714L;
-
-        protected ClassException(String message)
-        {
-            super("RuinTemplate: " + message);
-        }
-    }
-
-    public static class RequiredModNotActiveException extends ClassException
+    public static class IncompatibleModException extends RuntimeException
     {
         private static final long serialVersionUID = -6208915606622752271L;
 
-        public RequiredModNotActiveException(String template, String mod)
+        public IncompatibleModException(boolean required, String template, String mod)
         {
-            super("template \"" + template + "\" not installed because required mod \"" + mod + "\" not active");
-        }
-    }
-
-    public static class ProhibitedModActiveException extends ClassException
-    {
-        private static final long serialVersionUID = 7686853844820450433L;
-
-        public ProhibitedModActiveException(String template, String mod)
-        {
-            super("template \"" + template + "\" not installed because prohibited mod \"" + mod + "\" active");
+            super("template \"" + template + "\" not installed because " + (required ? "required" : "prohibited") +
+                    " mod \"" + mod + "\" " + (required ? "not active" : "active"));
         }
     }
 }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -459,7 +459,8 @@ class World2TemplateParser extends Thread
             pw.println("# authoring Player: " + player.getName());
             pw.println();
 
-            pw.println("# other mods required or prohibited by this template");
+            pw.println("# comma-separated list of mod ids required/prohibited to load template");
+            pw.println("# all required mods listed must be present; no prohibited mods can be");
             pw.println("requiredMods=");
             pw.println("prohibitedMods=");
             pw.println("# likelihood this template will be chosen relative to all others");
@@ -469,7 +470,7 @@ class World2TemplateParser extends Thread
             pw.println("# biome corresponding to directory is always assumed, listed or not");
             pw.println("# generic templates should leave this list empty");
             pw.println("biomesToSpawnIn=");
-            pw.println("# list of biome types (or ALL) in which this template may spawn");
+            pw.println("# list of biome types in which this template may spawn");
             pw.println("# this is in addition to those explicitly listed as biomesToSpawnIn");
             pw.println("# generic templates should leave this list empty");
             pw.println("biomeTypesToSpawnIn=");

--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -459,6 +459,9 @@ class World2TemplateParser extends Thread
             pw.println("# authoring Player: " + player.getName());
             pw.println();
 
+            pw.println("# other mods required or prohibited by this template");
+            pw.println("requiredMods=");
+            pw.println("prohibitedMods=");
             pw.println("# likelihood this template will be chosen relative to all others");
             pw.println("# e.g., a weight=6 template is chosen 3X as often as one with weight=2");
             pw.println("weight=1");

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -526,3 +526,4 @@ a: setAccessible now true
 + added config option to make /parseruin rules line up nicely
 + templates can now specify biomes to spawn in by type
 + enhance biomeTypesToSpawnIn with simple boolean operations
++ templates can now declare required/prohibited mods

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -151,7 +151,15 @@
 # If the space between max and min distances is too narrow (namely, less than
 # the length and width of the template), no instances can naturally generate.
 #
-# Ruins 17.2 adds three new optional variables:
+# Ruins 17.2 adds five new optional variables:
+#
+# requiredMods=<name1>,<name2>,<name3>...
+# prohibitedMods=<name1>,<name2>,<name3>...
+# Prevent installation of this template if a listed required mod is not active, or a listed
+# prohibited mod is active.
+# example: requiredMods=quark,tconstruct
+# example: prohibitedMods=forestry,natura
+# Optional. Both default to empty lists.
 #
 # biomeTypesToSpawnIn=<name1>,<name2>,<name3>...
 # Adds the Template being loaded (regardless which folder it is in) to every Ruins Biome


### PR DESCRIPTION
A feature I have in my local experimental Ruins and requested by Jordan_Peacock in a [Minecraft Forum post](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4413)--the ability for a template to declare mods that must be present, or can't be present, for it to be loaded. This is done via two new template variables: **requiredMods** and **prohibitedMods**. Pretty self explanatory. They both default to empty lists (i.e., nothing required, nothing prohibited).

So, for example, if I have a template that relies on blocks from the Quark and Tinkers' Construct mods, I'd specify:
**requiredMods=quark,tconstruct**
Then maybe I have an alternative template that only uses Quark:
**requiredMods=quark
prohibitedMods=tconstruct**
And one that only uses Tinkers':
**requiredMods=tconstruct
prohibitedMods=quark**
And finally one that doesn't use either:
**prohibitedMods=quark,tconstruct**
Only one of these four templates will be loaded by Ruins, depending on the combination of other mods installed. I don't expect people will use it that way, but they could. It's more likely they'll simply use **requiredMods** as a guarantee everything the template needs is available. That's cool, too.

Jordan_Peacock suggested it'd be ideal if Ruins made the determination itself, based on analyzing the contents of the template file. I went the variable route, because:
- The analysis would be quite complex, given that not only modded blocks in rules would need to be checked, but also entities, blocks, items, effects, etc. embedded in NBT tags and referred to in commands and inventories. Then there are modded biomes; Ruins doesn't support qualifying them with their associated mod names. Messy, messy.
- You may want to require a mod for reasons other than additional things it provides. Maybe, for example, I want some extra iron deposits sprinkled around to feed Thermal Expansion, but I don't want the excess iron if there's no big consumer of it. Nothing in the template file would indicate this.
- There's also no way to determine by the contents of a template whether a particular mod is _prohibited_, if that's ever a thing.