### PR TITLE
[Ruins] cache block states for efficient repeat use

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -1473,8 +1473,9 @@ public class RuinTemplateRule
             {
                 try
                 {
+                    // data value must be an integer from 0-15, inclusive
                     int value = Integer.parseInt(metadata);
-                    if ((value & ~0b1111) == 0)
+                    if (value >= 0 && value < 16)
                     {
                         state = block.getStateFromMeta(value);
                     }

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -529,3 +529,4 @@ a: setAccessible now true
 + templates can now specify biomes to spawn in by type
 + enhance biomeTypesToSpawnIn with simple boolean operations
 + templates can now declare required/prohibited mods
++ cache block states for efficient repeat use, 1.13 prep


### PR DESCRIPTION
This, like the comma-hiding pull #212, is another change to prepare for Minecraft 1.13, though it too isn't 1.13-specific and still works like a charm with 1.12. In fact, it provides a marginal improvement in 1.12, with (potentially) quicker structure-building performance and more thorough error reporting.

The main feature is the caching of computed block states rather than reinterpreting the data values each time a block is placed. It's not that significant a gain in 1.12, but it'll be much more relevant in 1.13, when parsing property lists will be kind of expensive. This change is transparent to end users (aside from now logging bad block data values in templates).