### PR TITLE
[Ruins] fix lumped IInventory rule parsing

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -1082,7 +1082,7 @@ public class RuinTemplateRule
     private void handleIInventory(IInventory inv, String itemDataWithoutNBT, RuinTextLumper lumper)
     {
         // example string:
-        // minecraft:stone#1#4#0+minecraft:written_book#NBT1#0#1+minecraft:chest#1#0#2
+        // minecraft:stone#1#4#0+minecraft:written_book#{NBT}#0#1+minecraft:chest#1#0#2
         ItemStack putItem;
         ItemStack slotItemPrev;
         String[] itemStrings = itemDataWithoutNBT.split(Pattern.quote("+"));
@@ -1104,10 +1104,13 @@ public class RuinTemplateRule
             boolean nbtdata = false;
             if (hashsplit.length > 1)
             {
-                nbtdata = hashsplit[1].startsWith("NBT");
-                if (!nbtdata)
+                try
                 {
-                    itemStackSize = Integer.valueOf(hashsplit[1]);
+                    itemStackSize = Integer.parseInt(hashsplit[1]);
+                }
+                catch (NumberFormatException exception)
+                {
+                    nbtdata = true;
                 }
             }
 


### PR DESCRIPTION
Found this while stress testing templates with inventory blocks. The IInventory code was explicitly looking for the old "lumped" text placeholder, which is no longer used. Nothing outside the lumping/unlumping process should be referring to placeholders anyway.

This change fixes NBT-tagged items in IInventory blocks.