### PR TITLE
[Ruins] remove extra layer of escape applied to template rules

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -9,8 +9,6 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringEscapeUtils;
-
 import com.google.common.collect.Lists;
 import com.mojang.authlib.GameProfile;
 
@@ -462,7 +460,7 @@ public class RuinTemplateRule
             }
             if (blockID == null)
             {
-                doSpecialBlock(world, random, x, y, z, blocknum, rotate, StringEscapeUtils.unescapeJava(blockString));
+                doSpecialBlock(world, random, x, y, z, blocknum, rotate, blockString);
             }
             else
             {

--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -9,8 +9,6 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 
-import org.apache.commons.lang3.StringEscapeUtils;
-
 import com.mojang.authlib.GameProfile;
 
 import net.minecraft.block.Block;
@@ -523,7 +521,7 @@ class World2TemplateParser extends Thread
             int rulenum = 1;
             for (BlockData bd : usedBlocks)
             {
-                pw.println("rule" + id_formatter.format(rulenum) + "=" + StringEscapeUtils.escapeJava(bd.toString()));
+                pw.println("rule" + id_formatter.format(rulenum) + "=" + bd.toString());
                 rulenum++;
             }
 

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -531,3 +531,4 @@ a: setAccessible now true
 + templates can now declare required/prohibited mods
 + cache block states for efficient repeat use, 1.13 prep
 + enhance requiredMods/biomeTypesToSpawnIn with fancier boolean operations
++ revert 15.2--no additional layer of escape needed for JSON, bugfix


### PR DESCRIPTION
This essentially reverts the change made in version 15.2, which did two things: 1) all template rules generated by /parseruin were escaped, and 2) all special block specifications in template rules were unescaped before being processed. I don't know why this was done, but it's problematic for a number of reasons.

First, while the comments surrounding 15.2 suggest JSON needs to be escaped, unescaping is applied to all other special block elements as well, such as command block commands and sign text. Second, it uses Java escape rules, which are different from JSON escape rules and may generate invalid character sequences. Third, it makes rules tougher to read and write.

Most of all, though, it makes it impossible to distinguish between quotes that are escaped because they're meant to be literal quote characters, and quotes that are escaped just because there's an extra layer of escaping applied (unless the literal quotes are doubly escaped--yuck). As a result, quoted strings within NBT tags can't be parsed correctly.

If I'm missing something and there really is a reason for the extra escaping, reject this pull, and I'll need to modify TextLumper to accommodate it--currently, it's not expecting escape sequences outside of strings, as there shouldn't be any. It'd probably be worthwhile confining the escaping and unescaping to NBT tags and using the appropriate conversions, too. I'd rather just get rid of it altogether, though.

Interestingly, as an aside, the only template included in the Ruins delivery that would be affected by this change--templateparser/cmdtest.tml--isn't, because it was created prior to 15.2 and doesn't have the extra layer of escaping.