### PR TITLE
[Ruins] omit tile entity absolute positions in template rules

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -242,6 +242,10 @@ class World2TemplateParser extends Thread
                     {
                         NBTTagCompound tc = new NBTTagCompound();
                         te.writeToNBT(tc);
+                        // remove absolute position tags
+                        tc.removeTag("x");
+                        tc.removeTag("y");
+                        tc.removeTag("z");
                         temp.data = "teBlock;" + Block.REGISTRY.getNameForObject(temp.block).toString() + ";" + tc.toString() + "-" + temp.meta;
                     }
                     else if (temp.block == Blocks.MOB_SPAWNER)

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -532,3 +532,4 @@ a: setAccessible now true
 + cache block states for efficient repeat use, 1.13 prep
 + enhance requiredMods/biomeTypesToSpawnIn with fancier boolean operations
 + revert 15.2--no additional layer of escape needed for JSON, bugfix
++ /parseruin rules no longer include tile entity absolute positions, bugfix


### PR DESCRIPTION
Jordan_Peacock noted in [Minecraft Forum post 4465](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4465) that **teBlock** rules don't "stack" as expected after a /parseruin--each instance of a particular block generates a separate unique rule rather than all of them using the same single rule. It's happening because, as mentioned in the post, the tile entity's full NBT data is used, including its absolute position, resulting in a different set of tags per block.

This change masks the absolute position (i.e., tags "x", "y", and "z") from a tile entity's NBT before writing it to the template file. They're irrelevant, since these tags are reassigned when the block is actually placed in-world. Now, otherwise identical **teBlock**s share the same rule.