### PR TITLE
Dungeon Tweaks Compat again

### DIFF
--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_BattleTowersCore.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_BattleTowersCore.java
@@ -87,6 +87,9 @@ public class AS_BattleTowersCore
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
+    	DungeonTweaksCompat.legacyCheck();
+    	DungeonTweaksCompat.registerDungeons();
+    	
         configuration = new Configuration(event.getSuggestedConfigurationFile(), false);
         loadForgeConfig();
 

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -154,7 +154,7 @@ public class AS_WorldGenTower
     }
 
     @SuppressWarnings("deprecation") // is needed because getDefaultState on stairs does not work
-    public void generate(World world, int ix, int jy, int kz, int towerchoice, boolean underground)
+    public void generate(World world, Random random, int ix, int jy, int kz, int towerchoice, boolean underground)
     {
         TowerTypes towerChosen = TowerTypes.values()[towerchoice];
 
@@ -387,19 +387,7 @@ public class AS_WorldGenTower
                         }
                         else
                         {
-                            try
-                            {
-                                @SuppressWarnings("unchecked")
-                                Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post")
-                                        .getConstructor(TileEntity.class, BlockPos.class, Random.class, ResourceLocation.class, World.class);
-                                Event event = constructor.newInstance(tileentitymobspawner, tileentitymobspawner.getPos(), world.rand, new ResourceLocation("battletowers:" + towerChosen.getName()),
-                                        world);
-                                MinecraftForge.EVENT_BUS.post(event);
-                            }
-                            catch (Throwable t)
-                            {
-                                t.printStackTrace();
-                            }
+                           DungeonTweaksCompat.fireDungeonSpawn(tileentitymobspawner, world, random, towerChosen);
                         }
                     }
 
@@ -413,19 +401,7 @@ public class AS_WorldGenTower
                         }
                         else
                         {
-                            try
-                            {
-                                @SuppressWarnings("unchecked")
-                                Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post")
-                                        .getConstructor(TileEntity.class, BlockPos.class, Random.class, ResourceLocation.class, World.class);
-                                Event event = constructor.newInstance(tileentitymobspawner, tileentitymobspawner.getPos(), world.rand, new ResourceLocation("battletowers:" + towerChosen.getName()),
-                                        world);
-                                MinecraftForge.EVENT_BUS.post(event);
-                            }
-                            catch (Throwable t)
-                            {
-                                t.printStackTrace();
-                            }
+                        	DungeonTweaksCompat.fireDungeonSpawn(tileentitymobspawner, world, random, towerChosen);
                         }
                     }
                 }
@@ -671,6 +647,11 @@ public class AS_WorldGenTower
         public String getName()
         {
             return this.typeName;
+        }
+        
+        public ResourceLocation getId()
+        {
+        	return new ResourceLocation("battletowers:" + this.typeName);
         }
     }
 

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_WorldGenTower.java
@@ -381,7 +381,7 @@ public class AS_WorldGenTower
                     TileEntityMobSpawner tileentitymobspawner = (TileEntityMobSpawner) world.getTileEntity(new BlockPos(ix + 2, builderHeight + 6, kz + 2));
                     if (tileentitymobspawner != null)
                     {
-                        if (!Loader.isModLoaded("dungeontweaks"))
+                        if (!DungeonTweaksCompat.isLoaded)
                         {
                             tileentitymobspawner.getSpawnerBaseLogic().setEntityId(getMobType(world.rand));
                         }
@@ -395,7 +395,7 @@ public class AS_WorldGenTower
                     tileentitymobspawner = (TileEntityMobSpawner) world.getTileEntity(new BlockPos(ix - 3, builderHeight + 6, kz + 2));
                     if (tileentitymobspawner != null)
                     {
-                        if (!Loader.isModLoaded("dungeontweaks"))
+                        if (!DungeonTweaksCompat.isLoaded)
                         {
                             tileentitymobspawner.getSpawnerBaseLogic().setEntityId(getMobType(world.rand));
                         }

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
@@ -82,9 +82,9 @@ public class DungeonTweaksCompat {
                     world);
 				MinecraftForge.EVENT_BUS.post(event);
 			}
-			catch (Throwable t)
+			catch (Exception e)
 			{
-				t.printStackTrace();
+				e.printStackTrace();
 			}
 		}
 		else
@@ -94,9 +94,9 @@ public class DungeonTweaksCompat {
 				Method fireDungeonTweaks = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("fireDungeonTweaks",ResourceLocation.class,TileEntity.class,Random.class,World.class);
 				fireDungeonTweaks.invoke(null, towerId, spawner, random, world);
 			}
-			catch(Throwable t)
+			catch(Exception e)
 			{
-				t.printStackTrace();
+				e.printStackTrace();
 			}
 		}
 	}

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
@@ -1,0 +1,104 @@
+package atomicstryker.battletowers.common;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Random;
+
+import com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonLocation;
+import com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs;
+
+import atomicstryker.battletowers.common.AS_WorldGenTower.TowerTypes;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.Event;
+/**
+ * this is backwards and modern dungeon tweaks compatible
+ * @author jredfox
+ *
+ */
+public class DungeonTweaksCompat {
+	
+	public static boolean isLegacy = false;
+	
+	/**
+	 * make backwards compatability when isLegacy becomes true
+	 */
+	public static void legacyCheck()
+	{
+		try
+		{
+			Class c = Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post");
+			isLegacy = true;
+		}
+		catch(Throwable t)
+		{
+			
+		}
+	}
+	/**
+	 * register all dungeon tweaks mobs to anydim towers
+	 */
+	public static void registerDungeons()
+	{
+		if(isLegacy) return;//I supported this mod in older versions
+		try
+		{
+			Method addDungeonMob = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("addDungeonMob", ResourceLocation.class,ResourceLocation.class,int.class);
+			for(AS_WorldGenTower.TowerTypes tower : AS_WorldGenTower.TowerTypes.values())
+			{
+				boolean nether = tower == TowerTypes.Netherrack;
+				addDungeonMob.invoke(null, tower.getId(), new ResourceLocation("cave_spider"), 100);
+				addDungeonMob.invoke(null,tower.getId(), new ResourceLocation("spider"), 90);
+				addDungeonMob.invoke(null,tower.getId(), nether ? new ResourceLocation("wither_skeleton") : new ResourceLocation("skeleton"), 120);
+				addDungeonMob.invoke(null,tower.getId(), new ResourceLocation("zombie"), 120);
+
+				if(nether)
+					addDungeonMob.invoke(null,tower.getId(), new ResourceLocation("blaze"), 20);
+			}
+		}
+		catch(Exception e)
+		{
+			e.printStackTrace();
+		}
+	}
+	/**
+	 * fire the event based upon tower definitions
+	 */
+	public static void fireDungeonSpawn(TileEntityMobSpawner spawner, World world, Random random, TowerTypes towerChosen)
+	{
+		ResourceLocation towerId = towerChosen.getId();
+		if(isLegacy)
+		{
+			try
+			{
+				@SuppressWarnings("unchecked")
+				Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post")
+                    .getConstructor(TileEntity.class, BlockPos.class, Random.class, ResourceLocation.class, World.class);
+				Event event = constructor.newInstance(spawner, spawner.getPos(), world.rand, towerId,
+                    world);
+				MinecraftForge.EVENT_BUS.post(event);
+			}
+			catch (Throwable t)
+			{
+				t.printStackTrace();
+			}
+		}
+		else
+		{
+			try
+			{
+				Method fireDungeonTweaks = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("fireDungeonTweaks",ResourceLocation.class,TileEntity.class,Random.class,World.class);
+				fireDungeonTweaks.invoke(null, towerId, spawner, random, world);
+			}
+			catch(Throwable t)
+			{
+				t.printStackTrace();
+			}
+		}
+	}
+
+}

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
@@ -4,9 +4,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Random;
 
-import com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonLocation;
-import com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs;
-
 import atomicstryker.battletowers.common.AS_WorldGenTower.TowerTypes;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityMobSpawner;
@@ -15,90 +12,102 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.Event;
+
 /**
  * this is backwards and modern dungeon tweaks compatible
+ * 
  * @author jredfox
  *
  */
-public class DungeonTweaksCompat {
-	
-	public static boolean isLegacy = false;
-	
-	/**
-	 * make backwards compatability when isLegacy becomes true
-	 */
-	public static void legacyCheck()
-	{
-		try
-		{
-			Class c = Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post");
-			isLegacy = true;
-		}
-		catch(Throwable t)
-		{
-			
-		}
-	}
-	/**
-	 * register all dungeon tweaks mobs to anydim towers
-	 */
-	public static void registerDungeons()
-	{
-		if(isLegacy) return;//I supported this mod in older versions
-		try
-		{
-			Method addDungeonMob = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("addDungeonMob", ResourceLocation.class,ResourceLocation.class,int.class);
-			for(AS_WorldGenTower.TowerTypes tower : AS_WorldGenTower.TowerTypes.values())
-			{
-				boolean nether = tower == TowerTypes.Netherrack;
-				addDungeonMob.invoke(null, tower.getId(), new ResourceLocation("cave_spider"), 100);
-				addDungeonMob.invoke(null,tower.getId(), new ResourceLocation("spider"), 90);
-				addDungeonMob.invoke(null,tower.getId(), nether ? new ResourceLocation("wither_skeleton") : new ResourceLocation("skeleton"), 120);
-				addDungeonMob.invoke(null,tower.getId(), new ResourceLocation("zombie"), 120);
+public class DungeonTweaksCompat
+{
 
-				if(nether)
-					addDungeonMob.invoke(null,tower.getId(), new ResourceLocation("blaze"), 20);
-			}
-		}
-		catch(Exception e)
-		{
-			e.printStackTrace();
-		}
-	}
-	/**
-	 * fire the event based upon tower definitions
-	 */
-	public static void fireDungeonSpawn(TileEntityMobSpawner spawner, World world, Random random, TowerTypes towerChosen)
-	{
-		ResourceLocation towerId = towerChosen.getId();
-		if(isLegacy)
-		{
-			try
-			{
-				@SuppressWarnings("unchecked")
-				Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post")
-                    .getConstructor(TileEntity.class, BlockPos.class, Random.class, ResourceLocation.class, World.class);
-				Event event = constructor.newInstance(spawner, spawner.getPos(), world.rand, towerId,
-                    world);
-				MinecraftForge.EVENT_BUS.post(event);
-			}
-			catch (Exception e)
-			{
-				e.printStackTrace();
-			}
-		}
-		else
-		{
-			try
-			{
-				Method fireDungeonTweaks = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("fireDungeonTweaks",ResourceLocation.class,TileEntity.class,Random.class,World.class);
-				fireDungeonTweaks.invoke(null, towerId, spawner, random, world);
-			}
-			catch(Exception e)
-			{
-				e.printStackTrace();
-			}
-		}
-	}
+    public static boolean isLegacy = false;
+
+    /**
+     * make backwards compatability when isLegacy becomes true
+     */
+    public static void legacyCheck()
+    {
+        try
+        {
+            Class c = Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post");
+            isLegacy = true;
+        }
+        catch (Throwable t)
+        {
+
+        }
+    }
+
+    /**
+     * register all dungeon tweaks mobs to anydim towers
+     */
+    public static void registerDungeons()
+    {
+        if (isLegacy)
+        {
+            return;// I supported this mod in older versions
+        }
+
+        try
+        {
+            Method addDungeonMob = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("addDungeonMob", ResourceLocation.class, ResourceLocation.class,
+                    int.class);
+            for (AS_WorldGenTower.TowerTypes tower : AS_WorldGenTower.TowerTypes.values())
+            {
+                boolean nether = tower == TowerTypes.Netherrack;
+                addDungeonMob.invoke(null, tower.getId(), new ResourceLocation("cave_spider"), 100);
+                addDungeonMob.invoke(null, tower.getId(), new ResourceLocation("spider"), 90);
+                addDungeonMob.invoke(null, tower.getId(), nether ? new ResourceLocation("wither_skeleton") : new ResourceLocation("skeleton"), 120);
+                addDungeonMob.invoke(null, tower.getId(), new ResourceLocation("zombie"), 120);
+
+                if (nether)
+                {
+                    addDungeonMob.invoke(null, tower.getId(), new ResourceLocation("blaze"), 20);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * fire the event based upon tower definitions
+     */
+    public static void fireDungeonSpawn(TileEntityMobSpawner spawner, World world, Random random, TowerTypes towerChosen)
+    {
+        ResourceLocation towerId = towerChosen.getId();
+        if (isLegacy)
+        {
+            try
+            {
+                @SuppressWarnings("unchecked")
+                Constructor<? extends Event> constructor = (Constructor<? extends Event>) Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post").getConstructor(TileEntity.class,
+                        BlockPos.class, Random.class, ResourceLocation.class, World.class);
+                Event event = constructor.newInstance(spawner, spawner.getPos(), world.rand, towerId, world);
+                MinecraftForge.EVENT_BUS.post(event);
+            }
+            catch (Throwable t)
+            {
+                t.printStackTrace();
+            }
+        }
+        else
+        {
+            try
+            {
+                Method fireDungeonTweaks = Class.forName("com.evilnotch.dungeontweeks.main.world.worldgen.mobs.DungeonMobs").getMethod("fireDungeonTweaks", ResourceLocation.class, TileEntity.class,
+                        Random.class, World.class);
+                fireDungeonTweaks.invoke(null, towerId, spawner, random, world);
+            }
+            catch (Throwable t)
+            {
+                t.printStackTrace();
+            }
+        }
+    }
 
 }

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/DungeonTweaksCompat.java
@@ -11,6 +11,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.eventhandler.Event;
 
 /**
@@ -23,12 +24,20 @@ public class DungeonTweaksCompat
 {
 
     public static boolean isLegacy = false;
+    public static boolean isLoaded = false;
 
     /**
      * make backwards compatability when isLegacy becomes true
      */
     public static void legacyCheck()
     {
+        isLoaded = Loader.isModLoaded("dungeontweaks");
+        
+        if(!isLoaded)
+        {
+            return;
+        }
+        
         try
         {
             Class c = Class.forName("com.EvilNotch.dungeontweeks.main.Events.EventDungeon$Post");
@@ -45,7 +54,7 @@ public class DungeonTweaksCompat
      */
     public static void registerDungeons()
     {
-        if (isLegacy)
+        if (!isLoaded || isLegacy)
         {
             return;// I supported this mod in older versions
         }

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/WorldGenHandler.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/WorldGenHandler.java
@@ -148,7 +148,7 @@ public class WorldGenHandler implements IWorldGenerator
         if (choice >= 0)
         {
             pos.underground = world.rand.nextInt(100) + 1 < AS_BattleTowersCore.instance.chanceTowerIsUnderGround;
-            generator.generate(world, x, y, z, choice, pos.underground);
+            generator.generate(world, random, x, y, z, choice, pos.underground);
             return true;
         }
 
@@ -158,7 +158,7 @@ public class WorldGenHandler implements IWorldGenerator
     public static void generateTower(World world, int x, int y, int z, int type, boolean underground)
     {
         disableGenerationHook++;
-        instance.generator.generate(world, x, y, z, type, underground);
+        instance.generator.generate(world, world.rand, x, y, z, type, underground);
         obtainTowerPosListAccess();
         towerPositions.add(instance.new TowerPosition(x, y, z, type, underground));
         releaseTowerPosListAccess();
@@ -460,7 +460,7 @@ public class WorldGenHandler implements IWorldGenerator
 
         if (chosen != null)
         {
-            instance.generator.generate(world, chosen.x, chosen.y, chosen.z, AS_WorldGenTower.TowerTypes.Null.ordinal(), chosen.underground);
+            instance.generator.generate(world, world.rand, chosen.x, chosen.y, chosen.z, AS_WorldGenTower.TowerTypes.Null.ordinal(), chosen.underground);
             obtainTowerPosListAccess();
             towerPositions.remove(chosen);
             releaseTowerPosListAccess();
@@ -490,7 +490,7 @@ public class WorldGenHandler implements IWorldGenerator
         obtainTowerPosListAccess();
         for (TowerPosition tp : towerPositions)
         {
-            instance.generator.generate(world, tp.x, tp.y, tp.z, regenerate ? tp.type : AS_WorldGenTower.TowerTypes.Null.ordinal(), tp.underground);
+            instance.generator.generate(world, world.rand, tp.x, tp.y, tp.z, regenerate ? tp.type : AS_WorldGenTower.TowerTypes.Null.ordinal(), tp.underground);
         }
 
         if (!regenerate)

--- a/BattleTowers/src/main/resources/pack.mcmeta
+++ b/BattleTowers/src/main/resources/pack.mcmeta
@@ -1,7 +1,0 @@
-{
-    "pack": {
-        "description": "examplemod resources",
-        "pack_format": 3,
-        "_comment": "A pack_format of 3 should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang). A pack_format of 2 will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang)."
-    }
-}

--- a/BattleTowers/src/main/resources/pack.mcmeta
+++ b/BattleTowers/src/main/resources/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+    "pack": {
+        "description": "examplemod resources",
+        "pack_format": 3,
+        "_comment": "A pack_format of 3 should be used starting with Minecraft 1.11. All resources, including language files, should be lowercase (eg: en_us.lang). A pack_format of 2 will load your mod resources with LegacyV2Adapter, which requires language files to have uppercase letters (eg: en_US.lang)."
+    }
+}


### PR DESCRIPTION
this has backwards compatibility with older dungeon tweaks and the core function re-write update of 1.2.5. This code is also cleaner I hope you will merge this. **And yes still this is still a soft dependency**

Why do you need to register dungeon entries by default now?: it's to instantiate weights that are not 0 for towers. Users are still able to override the weights via config file it's just the weight won't be default. Also my re-write didn't support any specific mob entries only definitions. If you need the method to be taken down I could add support on my side for weights but, the rest needs to happen.

Also if you don't like my nether specific enhancements by default when dungeon tweaks is loaded I could remove that and have users config them to be that or whatever they wanted. Just thought it would be cool. 

Thanks for your time