### PR TITLE
[Ruins] interpret IInventory block as block, not item

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -536,7 +536,7 @@ public class RuinTemplateRule
         }
         else if (dataString.startsWith("IInventory;"))
         {
-            return tryFindingObject(dataString.split(";")[1]) instanceof Block;
+            return Block.REGISTRY.containsKey(new ResourceLocation(dataString.split(";")[1]));
         }
         else if (dataString.equals("EnderCrystal"))
         {
@@ -614,10 +614,9 @@ public class RuinTemplateRule
             RuinTextLumper lumper = new RuinTextLumper(owner, excessiveDebugging ? debugPrinter : null);
             String dataWithoutNBT = lumper.lump(dataString);
             String[] s = dataWithoutNBT.split(";");
-            Object o = tryFindingObject(s[1]);
-            if (o instanceof Block)
+            Block b = Block.REGISTRY.getObject(new ResourceLocation(s[1]));
+            if (b != Blocks.AIR)
             {
-                Block b = (Block) o;
                 // need to strip meta '-x' value if present
                 if (s[2].lastIndexOf("-") > s[2].length() - 5)
                 {

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -534,3 +534,6 @@ a: setAccessible now true
 + revert 15.2--no additional layer of escape needed for JSON, bugfix
 + /parseruin rules no longer include tile entity absolute positions, bugfix
 + configure teBlock TileEntity correctly--allows execute-on-spawn command blocks, bugfix
+
+17.3
++ interpret IInventory block as block instead of item, bugfix

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -326,7 +326,7 @@ preserve_lava=0
 #
 # Ruins 15.0 adds support for tile entity NBT data. This is best achieved by adding the blockname to the global "teblock" variable in ruins.txt
 # Usage: teBlock;<blockName>;<nbttag json>-<blockrotation>
-# Example: rule1=0,100,teBlock;minecraft:trapped_chest;{x:-156,y:65,z:72,Items:[0:{Slot:12b,id:5s,Count:1b,Damage:0s},1:{Slot:13b,id:24s,Count:1b,Damage:1s}],id:"Chest"}-2
+# Example: rule1=0,100,teBlock;minecraft:trapped_chest;{Items:[0:{Slot:12b,id:5s,Count:1b,Damage:0s},1:{Slot:13b,id:24s,Count:1b,Damage:1s}],id:"Chest"}-2
 # Note: "Chain" and "Repeat" Command Blocks are classified as such by default
 #
 # Ruins 16.8 modifies the rule syntax a bit to add some new features (variants and variant groups, in particular). None


### PR DESCRIPTION
The first field of an **IInventory** block template specification must be a block ID. However, it was being interpreted as a possible item ID, with a block ID then derived from the item, if there is one. This isn't guaranteed to work...and, if fact, doesn't for **minecraft:brewing_stand**, among others.

This change fixes that, forcing the first field to be interpreted strictly as a block ID. It now works for all **IInventory** blocks. Note the analogous **teBlock** code already handles this correctly and needn't be changed.
