### PR TITLE
[Ruins] lump teBlock spec before splitting into fields

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -710,7 +710,9 @@ public class RuinTemplateRule
             }
             // examples: teBlock;minecraft:trapped_chest;{...nbt json...},
             // teBlock;minecraft:trapped_chest;{...nbt json...}-4
-            String[] in = dataString.split(";");
+            RuinTextLumper lumper = new RuinTextLumper(owner, excessiveDebugging ? debugPrinter : null);
+            String dataWithoutNBT = lumper.lump(dataString);
+            String[] in = dataWithoutNBT.split(";");
             Block b = Block.REGISTRY.getObject(new ResourceLocation(in[1]));
             if (excessiveDebugging)
             {
@@ -720,7 +722,8 @@ public class RuinTemplateRule
             {
                 try
                 {
-                    NBTTagCompound tc = JsonToNBT.getTagFromJson(in[2].substring(0, in[2].lastIndexOf('}') + 1));
+                    final String json = lumper.unlump(in[2]);
+                    NBTTagCompound tc = JsonToNBT.getTagFromJson(json.substring(0, json.lastIndexOf('}') + 1));
                     tc.setInteger("x", x);
                     tc.setInteger("y", y);
                     tc.setInteger("z", z);

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -537,3 +537,4 @@ a: setAccessible now true
 
 17.3
 + interpret IInventory block as block instead of item, bugfix
++ lump teBlock spec before splitting into fields, bugfix


### PR DESCRIPTION
As pointed out by Mensrea in [Minecraft Forum post 4541](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4541), NBT parsing for **teBlock** doesn't work if the NBT contains a semicolon, the delimiter used to separate **teBlock** fields. Looks like a job for TextLumper!

With this change, semicolons no longer break NBT specifications.