### PR TITLE
[Ruins] resolve RuinsPositionsFile.txt concurrency issues

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Random;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -29,14 +30,14 @@ class RuinGenerator
     private final File ruinsDataFile;
     private final File ruinsDataFileWriting;
 
-    private static boolean flushing;
+    private AtomicBoolean flushing;
 
     public RuinGenerator(FileHandler rh, World world)
     {
         fileHandler = rh;
         stats = new RuinStats();
         registeredRuins = new ConcurrentSkipListSet<>();
-        flushing = false;
+        flushing = new AtomicBoolean(false);
 
         ruinsDataFile = new File(rh.saveFolder, fileName);
         ruinsDataFileWriting = new File(rh.saveFolder, fileName + "_writing");
@@ -49,19 +50,26 @@ class RuinGenerator
         @Override
         public void run()
         {
-            loadPosFile(ruinsDataFile);
+            // prevent conflict with flush operation
+            synchronized (ruinsDataFile)
+            {
+                loadPosFile(ruinsDataFile);
+            }
         }
     }
 
     void flushPosFile(String worldName)
     {
-        if (flushing || registeredRuins.isEmpty() || worldName.equals("MpServer"))
+        if (registeredRuins.isEmpty() || worldName.equals("MpServer"))
         {
             return;
         }
 
-        flushing = true;
-        new FlushThread().start();
+        // begin new flush operation unless another already in progress
+        if (flushing.compareAndSet(false, true))
+        {
+            new FlushThread().start();
+        }
     }
 
     private class FlushThread extends Thread
@@ -69,11 +77,23 @@ class RuinGenerator
         @Override
         public void run()
         {
+            try
+            {
+                doFlush();
+            }
+            finally
+            {
+                // clear flush-in-progress flag regardless of outcome
+                flushing.set(false);
+            }
+        }
+
+        private void doFlush()
+        {
             if (ruinsDataFileWriting.exists())
             {
                 if (!ruinsDataFileWriting.delete())
                 {
-                    flushing = false;
                     throw new RuntimeException("Ruins crashed trying to access file " + ruinsDataFileWriting);
                 }
             }
@@ -106,24 +126,24 @@ class RuinGenerator
                 pw.close();
                 // System.out.println("Ruins Positions flushed, entries "+registeredRuins.size());
 
-                if (ruinsDataFile.exists())
+                // prevent conflict with load operation
+                synchronized (ruinsDataFile)
                 {
-                    if (!ruinsDataFile.delete())
+                    if (ruinsDataFile.exists())
                     {
-                        flushing = false;
+                        if (!ruinsDataFile.delete())
+                        {
+                            throw new RuntimeException("Ruins crashed trying to access file " + ruinsDataFileWriting);
+                        }
+                    }
+                    if (!ruinsDataFileWriting.renameTo(ruinsDataFile))
+                    {
                         throw new RuntimeException("Ruins crashed trying to access file " + ruinsDataFileWriting);
                     }
                 }
-                if (!ruinsDataFileWriting.renameTo(ruinsDataFile))
-                {
-                    flushing = false;
-                    throw new RuntimeException("Ruins crashed trying to access file " + ruinsDataFileWriting);
-                }
-                flushing = false;
             }
             catch (IOException e)
             {
-                flushing = false;
                 e.printStackTrace();
             }
         }

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -538,3 +538,4 @@ a: setAccessible now true
 17.3
 + interpret IInventory block as block instead of item, bugfix
 + lump teBlock spec before splitting into fields, bugfix
++ resolve RuinsPositionsFile.txt concurrency issues, bugfix


### PR DESCRIPTION
This change is intended to address a logged error reported in the Minecraft Forum by [kellixon](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4502) ([twice](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4528)) and [boyslittle](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4579). Unfortunately, I'm not able to duplicate the error myself--its occurrence depends on unpredictable thread timing--so I can't confirm with certainty the reported problem is resolved. This change _does_ correct a couple real errors, though, and should go in regardless.

The primary issue, at least with regard to the error called out in the Forum, is the fact **RuinsGenerator.flushing** was incorrectly declared to be static, causing clashes between threads attempting to flush position data for different dimensions. Other somewhat-related fixes applied while I was in the neighborhood: checking and setting the **flushing** flag is now an atomic operation, contention between threads (load/flush) for access to **RuinsPositionsFile.txt** is eliminated, and set flags no longer leak after a flush. All these modifications enhance the thread-safety of RuinsGenerator.

With these changes in place, the code behaves as I believe was intended. Whether the intended behavior is appropriate, however, is another question. Specifically, I'm not sure flushing--or even ruin generation--should proceed at all until after loading is complete. I also don't think a flush in progress should inhibit subsequent flush attempts; seems to me the one in progress should be canceled in favor of the later one, in case more ruins were added. Performance might be improved by keeping track of what was added since the last flush instead of dumping everything every time. As this pull isn't meant to alter the existing design, though, these matters are best left for future consideration.