### PR TITLE
[Ruins] optionally allow /testruin to ignore world ceiling

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.world.World;
 
 class CommandTestTemplate extends CommandBase
 {
@@ -26,7 +27,7 @@ class CommandTestTemplate extends CommandBase
     @Override
     public String getUsage(ICommandSender var1)
     {
-        return "/testruin TEMPLATENAME [X Y Z ROTATION] manually spawns the target Ruin of the templateparser folder, [] optional";
+        return "/testruin TEMPLATENAME [X Y Z [ROTATION [IGNORE_CEILING]]] manually spawns the target Ruin of the templateparser folder, [] optional";
     }
 
     @Override
@@ -50,7 +51,7 @@ class CommandTestTemplate extends CommandBase
             {
                 if (parsedRuin != null)
                 {
-                    parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, xpos, ypos, zpos, RuinsMod.DIR_NORTH, is_player);
+                    parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, xpos, ypos, zpos, RuinsMod.DIR_NORTH, is_player, false);
                     parsedRuin = null;
                 }
                 else
@@ -103,16 +104,19 @@ class CommandTestTemplate extends CommandBase
             {
                 parsedRuin = new RuinTemplate(new PrintWriter(System.out, true), file.getCanonicalPath(), file.getName(), is_player);
                 int rotation = (args.length > 4) ? Integer.parseInt(args[4]) : RuinsMod.DIR_NORTH;
+                final boolean ignore_ceiling = args.length > 5 && Boolean.parseBoolean(args[5]);
+                final World world = sender.getEntityWorld();
 
                 if (parsedRuin != null)
                 {
                     if (y < 0)
                     {
-                        for (y = RuinGenerator.WORLD_MAX_HEIGHT - 1; y > 7; y--)
+                        final int ceiling = ignore_ceiling ? world.getHeight() : world.getActualHeight();
+                        for (y = ceiling - 1; y > 7; y--)
                         {
                             BlockPos pos = new BlockPos(x, y, z);
-                            final Block b = sender.getEntityWorld().getBlockState(pos).getBlock();
-                            if (parsedRuin.isIgnoredBlock(b, sender.getEntityWorld(), pos))
+                            final Block b = world.getBlockState(pos).getBlock();
+                            if (parsedRuin.isIgnoredBlock(b, world, pos))
                             {
                                 continue;
                             }
@@ -127,7 +131,7 @@ class CommandTestTemplate extends CommandBase
                         ++y;
                     }
 
-                    if (parsedRuin.doBuild(sender.getEntityWorld(), sender.getEntityWorld().rand, x, y, z, rotation, is_player) >= 0)
+                    if (parsedRuin.doBuild(world, world.rand, x, y, z, rotation, is_player, ignore_ceiling) >= 0)
                     {
                         parsedRuin = null;
                     }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
@@ -234,7 +234,7 @@ class RuinGenerator
                     return;
                 }
 
-                int finalY = ruinTemplate.doBuild(world, random, x, y, z, rotate, false);
+                int finalY = ruinTemplate.doBuild(world, random, x, y, z, rotate, false, false);
                 if (finalY >= 0)
                 {
                     if (!fileHandler.disableLogging)

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -321,11 +321,11 @@ public class RuinTemplate
     /**
      * @return the finalized y value of the embedded template or -1 if there was an exception
      */
-    public int doBuild(World world, Random random, int xBase, int yBase, int zBase, int rotate, boolean is_player)
+    public int doBuild(World world, Random random, int xBase, int yBase, int zBase, int rotate, boolean is_player, boolean ignore_ceiling)
     {
         try
         {
-            return doBuildNested(world, random, xBase, yBase, zBase, rotate, is_player);
+            return doBuildNested(world, random, xBase, yBase, zBase, rotate, is_player, ignore_ceiling);
         }
         catch (Exception e)
         {
@@ -336,7 +336,7 @@ public class RuinTemplate
         }
     }
 
-    private int doBuildNested(World world, Random random, int xBase, int yBase, int zBase, int rotate, boolean is_player)
+    private int doBuildNested(World world, Random random, int xBase, int yBase, int zBase, int rotate, boolean is_player, boolean ignore_ceiling)
     {
         /*
          * we need to shift the base coordinates and take care of any rotations
@@ -355,7 +355,8 @@ public class RuinTemplate
         int y_off = -embed + ((randomOffMax > randomOffMin) ? (random.nextInt(randomOffMax - randomOffMin) + randomOffMin) : 0);
 
         // height sanity check
-        final int yReturn = Math.max(Math.min(yBase + y_off, world.getActualHeight() - height), 8);
+        final int ceiling = ignore_ceiling ? world.getHeight() : world.getActualHeight();
+        final int yReturn = Math.max(Math.min(yBase + y_off, ceiling - height), 8);
         final int y = yReturn - y_off;
 
         // override rotation wishes if its locked by template
@@ -509,7 +510,7 @@ public class RuinTemplate
                 if (targetY >= 0 && Math.abs(yReturn - targetY) <= ad.acceptableY)
                 {
                     debugPrinter.printf("Creating adjoining %s of Ruin %s at [%d|%d|%d], rot:%d\n", ad.adjoiningTemplate.getName(), getName(), targetX, targetY, targetZ, newrot);
-                    ad.adjoiningTemplate.doBuild(world, random, targetX, targetY, targetZ, newrot, false);
+                    ad.adjoiningTemplate.doBuild(world, random, targetX, targetY, targetZ, newrot, false, ignore_ceiling);
                 }
                 else
                 {

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -538,3 +538,4 @@ a: setAccessible now true
 17.3
 + interpret IInventory block as block instead of item, bugfix
 + lump teBlock spec before splitting into fields, bugfix
++ optionally allow /testruin to ignore world ceiling

--- a/Ruins/src/main/resources/readme.txt
+++ b/Ruins/src/main/resources/readme.txt
@@ -38,10 +38,11 @@ see https://www.youtube.com/watch?v=E9cNolY_LsQ for a in-depth explanation
 tldw: make a one-block plate the width and thickness of the template from one block which is not part of the template. build template on top. use command, give filename. break one block of plate.
 for advanced features such as basements consult template_rules.txt
 
-/testruin TEMPLATENAME [X Y Z [ROTATION]]
+/testruin TEMPLATENAME [X Y Z [ROTATION [IGNORE_CEILING]]]
 [] parts are optional each. TEMPLATENAME is either a filename in the "templateparser" biome folder or a folder and a template filename aka ocean/lighthouse
 testruin can be called exactly once without any arguments after successfully parsing a template in order to immediatly test that template
 rotation is 0 for 'none', 1 for EAST 'one to the right', 2 for SOUTH 'two to the right', 3 for WEST 'three to the right'
+specify IGNORE_CEILING 'true' to allow blocks to Y=255; otherwise, ruin is constrained by world height (e.g., max Y=127 in nether)  
 testruin supports minecraft relative coordinates, and can be called by command blocks
 testruin also supports using '_' instead of a relative or absolute y coordinate, which will let ruins find a suitable y using its spawner algorithm for given x,z
 


### PR DESCRIPTION
This is a proposed implementation of a new feature proposed by drakray (issue #241). It adds an optional parameter to the end of the **/testruin** command, making the syntax now...
`/testruin TEMPLATENAME [X Y Z [ROTATION [IGNORE_CEILING]]]`
...where IGNORE_CEILING can be specified as **true** to allow the template to place blocks all the way up to the maximum allowed by Minecraft (255), regardless of the limit imposed by the world height (e.g., 127 in the nether). Otherwise, the world height limit applies, as normal.

Regular worldgen is unaffected by this change, always observing the height limit. It might be interesting to also add, say, a template parameter allowing ruins to naturally spawn up there, too, but that raises some usability issues best left for another day..