### PR TITLE
[Ruins] reset mod upon server launch

### DIFF
--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -541,3 +541,5 @@ a: setAccessible now true
 + improve readability of /parseruin parameter settings
 + optionally allow /testruin to ignore world ceiling
 + resolve RuinsPositionsFile.txt concurrency issues, bugfix
++ reset Ruins upon server launch--now uses proper world folder, bugfix
++ consider dimension in "recursive generator" check, bugfix


### PR DESCRIPTION
This change primarily fixes the error identified by boyslittle in [a recent Minecraft Forum post](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4589). Ruins was initializing its worldgen database (**RuinsMod.generatorMap**) only once, on the mod load event. As a result, when running Singleplayer, Ruins continued to read from and write to the same world folder, even if the player switched to a different world. Notably, if that initial world was deleted and a new world created in the same game session, a "cannot find the path" error was thrown.

Ruins now listens for the **ServerAboutToStart** event and reinitializes its worldgen database accordingly, associating the selected world with its appropriate corresponding folder.

While I was in the area, I also made a correction to the code responsible for catching recursive generator calls. It was only looking at chunk coordinates and not considering the dimension in which the chunk was located. This could potentially (albeit rarely) lead to false positives; it's perfectly legitimate for the same chunk coordinates in different dimensions to be under generation simultaneously. Now, each dimension has its own "recursion watcher."