### PR TITLE
[Ruins] allow fractional weights and chances

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -33,7 +33,8 @@ public class RuinTemplate
 {
     private final String name;
     private Block[] acceptedSurfaces, deniedSurfaces;
-    private int height = 0, width = 0, length = 0, overhang = 0, weight = 1, embed = 0, randomOffMin = 0, randomOffMax = 0;
+    private int height = 0, width = 0, length = 0, overhang = 0, embed = 0, randomOffMin = 0, randomOffMax = 0;
+    private double weight = 1;
     private int leveling = 2, lbuffer = 0, w_off = 0, l_off = 0;
     public int uniqueMinDistance = 0;
     public int spawnMinDistance = 0;
@@ -103,7 +104,7 @@ public class RuinTemplate
         return name;
     }
 
-    public int getWeight()
+    public double getWeight()
     {
         return weight;
     }
@@ -906,7 +907,7 @@ public class RuinTemplate
                 else if (line.startsWith("weight"))
                 {
                     String[] check = line.split("=");
-                    weight = Integer.parseInt(check[1]);
+                    weight = Math.max(Double.parseDouble(check[1]), 0);
                 }
                 else if (line.startsWith("embed_into_distance"))
                 {

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -543,3 +543,5 @@ a: setAccessible now true
 + resolve RuinsPositionsFile.txt concurrency issues, bugfix
 + reset Ruins upon server launch--now uses proper world folder, bugfix
 + consider dimension in "recursive generator" check, bugfix
++ allow floating point block and template weights, rule and specific_biome chance values
++ remove extra +1% generic spawn chance, bugfix

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -336,8 +336,8 @@ preserve_lava=0
 # * Block Weighting: Instead of repeating block IDs in a rule to manipulate their probabilities of occurrence, weight
 # factors may now be used. This can make rules shorter and, in certain circumstances, more efficient. Apply a weight to
 # any block in a rule by preceding it with a prefix of the form "n*"; this is functionally equivalent to repeating the
-# same block n times. Valid values for n are integers between 1 and 99999, inclusive. For example, the following rules
-# are essentially identical, each producing blocks of dirt, mossy_cobblestone, and gravel with the same likelihood:
+# same block n times. For example, the following rules are essentially identical, each producing blocks of dirt,
+# mossy_cobblestone, and gravel with the same likelihood:
 #     rule1=0,100,dirt,dirt,mossy_cobblestone,dirt,gravel,dirt,mossy_cobblestone,mossy_cobblestone,dirt
 #     rule2=0,100,5*dirt,gravel,3*mossy_cobblestone
 # Weights are optional. If no weight is specified for a block in a rule, a weight of 1 is assumed.
@@ -357,7 +357,8 @@ preserve_lava=0
 #
 # * Rule Variant Weighting: Weights can be applied to rule variants to adjust the probability with which they are
 # selected. As with block weighting, a prefix of the form "n*" is placed at the beginning of the variant (i.e., just
-# after the = or ^) to assign it a weight. For example, you can use this rule for the windows in your structure:
+# after the = or ^) to assign it a weight. Unlike block weights, however, variant weights must be integers. For
+# example, you can use this rule for the windows in your structure:
 #     rule6=3*0,100,2*stained_glass-14
 #     ^0,100,stained_glass-4
 #     ^5*0,100,stained_glass-11


### PR DESCRIPTION
This changes the following elements so they no longer need be whole numbers:
- configured chances for biome-specific spawns--specific_forest=**98.5**
- template spawn weights--weight=**0.5**
- chances for template rule occurrence--rule3=0,**2.5**,dirt
- template rule block weights--rule5=0,100,cobblestone,**0.1***mossy_cobblestone

Whole numbers can still be used, of course, so existing templates aren't affected. Note the following have _not_ been changed and must remain integers:
- template rule variant weights--rule7=**3***0,100,gravel
- template rule variant group repeat counts--**5***rule9=0,100,sand

In addition, an existing bug causing specific spawn chances to be 1% lower than what was specified in **Ruins.txt** was fixed.