### PR TITLE
[Ruins] templates can specify dimensions to spawn in

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/FileHandler.java
@@ -18,6 +18,7 @@ import com.google.common.io.Files;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.DimensionType;
 import net.minecraft.world.biome.Biome;
 
 class FileHandler
@@ -234,7 +235,7 @@ class FileHandler
         vars.put(biomeName, val);
     }
 
-    private static final Pattern patternSpecificBiome = Pattern.compile("\\s*+specific_([^\\s=]++)\\s*+=\\s*+([^\\s#]++)");
+    private static final Pattern patternSpecificBiome = Pattern.compile("specific_([^=]++)=(.++)");
 
     private void readPerWorldOptions(File dir, PrintWriter ruinsLog) throws Exception
     {
@@ -323,7 +324,7 @@ class FileHandler
                     }
                 }
             }
-            else if ((matcher = patternSpecificBiome.matcher(read)).lookingAt())
+            else if ((matcher = patternSpecificBiome.matcher(read)).matches())
             {
                 boolean found = false;
                 Biome bgb;
@@ -359,6 +360,7 @@ class FileHandler
         RuinTemplate r;
         Biome bgb;
         File[] listFiles = path.listFiles();
+        final String dimensionName = DimensionType.getById(dimension).getName();
         if (listFiles != null)
         {
             for (File f : listFiles)
@@ -366,6 +368,10 @@ class FileHandler
                 try
                 {
                     r = new RuinTemplate(pw, f.getCanonicalPath(), f.getName());
+                    if (!r.acceptsDimension(dimensionName))
+                    {
+                        continue;
+                    }
                     targetList.add(r);
                     for (String biomeName : r.getBiomesToSpawnIn())
                     {

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplate.java
@@ -48,6 +48,7 @@ public class RuinTemplate
     private boolean preventRotation = false;
     private final ArrayList<Integer> bonemealMarkers;
     private final ArrayList<AdjoiningTemplateData> adjoiningTemplates;
+    private final Set<String> acceptedDimensions = new HashSet<>();
 
     private class AdjoiningTemplateData
     {
@@ -855,6 +856,14 @@ public class RuinTemplate
                         deniedSurfaces = inacceptables.toArray(deniedSurfaces);
                     }
                 }
+                else if (line.startsWith("dimensionsToSpawnIn"))
+                {
+                    String[] check = line.split("=");
+                    if (check.length > 1)
+                    {
+                        Collections.addAll(acceptedDimensions, check[1].split(","));
+                    }
+                }
                 else if (line.startsWith("dimensions"))
                 {
                     String[] check = line.split("=");
@@ -1129,6 +1138,11 @@ public class RuinTemplate
     public Block getAirBlock()
     {
         return Blocks.AIR;
+    }
+
+    public boolean acceptsDimension(final String dimension)
+    {
+        return acceptedDimensions.isEmpty() || dimension != null && !dimension.isEmpty() && acceptedDimensions.contains(dimension);
     }
 
     // A VariantRuleset is a list of template rules, some of which may have a number of variant versions from which the

--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -472,6 +472,10 @@ class World2TemplateParser extends Thread
             pw.println("# e.g., a weight=6 template is chosen 3X as often as one with weight=2");
             pw.println("weight=1");
             pw.println("#");
+            pw.println("# list of dimensions in which this template may spawn, even if generic");
+            pw.println("# one or more dimension names, separated by commas (blank = all)");
+            pw.println("dimensionsToSpawnIn=");
+            pw.println("#");
             pw.println("# list of other biomes in which this template may spawn");
             pw.println("# biome corresponding to directory is always assumed, listed or not");
             pw.println("# generic templates should leave this list empty");

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -545,3 +545,5 @@ a: setAccessible now true
 + consider dimension in "recursive generator" check, bugfix
 + allow floating point block and template weights, rule and specific_biome chance values
 + remove extra +1% generic spawn chance, bugfix
++ support biome names containing spaces
++ templates can now specify dimensions to spawn in

--- a/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
+++ b/Ruins/src/main/resources/examplesAndDocs/template_rules.txt
@@ -187,6 +187,12 @@
 # and is of lower precedence than + and -; parentheses may be used to further control the
 # order of evaluation.
 #
+# Ruins 17.3 adds optional variable "dimensionsToSpawnIn" to specify in which
+# dimensions the template's structures may appear. Note this applies to generic
+# spawning as well. List one or more dimensions by name, separated by commas,
+# or leave blank (default) to allow all dimensions.
+# example: dimensionsToSpawnIn=overworld,twilight_forest
+#
 
 weight=5
 embed_into_distance=1


### PR DESCRIPTION
This is primarily to address [Blackendsuns96571's post in the Minecraft Forum](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-12-ruins-structure-spawning-system?comment=4610) regarding compatibility with Galacticraft. It does have general utility, though, such as templates that, say, only spawn in the nether, or only in the overworld and Twilight Forest.

In addition, this change also supports biome names containing spaces, which Galacticraft uses (and possibly other mods).

Since this is a new feature, I'm not merging it myself, at least until I get a thumbs-up from AtomicStryker.