### PR TITLE
Implemented InfernalMobs Hwyla/WAILA integration.

### DIFF
--- a/InfernalMobs/build.gradle
+++ b/InfernalMobs/build.gradle
@@ -30,3 +30,16 @@ curseforge {
         }
     }
 }
+
+repositories {
+    maven {
+        name "Tehnut Maven FS"
+        url "https://tehnut.info/maven"
+    }
+}
+
+apply plugin: 'maven'
+
+dependencies {
+    deobfCompile "mcp.mobius.waila:Hwyla:1.8.26-B41_1.12.2"
+}

--- a/InfernalMobs/src/main/java/atomicstryker/infernalmobs/common/InfernalMobsCore.java
+++ b/InfernalMobs/src/main/java/atomicstryker/infernalmobs/common/InfernalMobsCore.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import atomicstryker.infernalmobs.plugins.waila.WailaRegistrar;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 
@@ -166,6 +167,8 @@ public class InfernalMobsCore
         networkHelper = new NetworkHelper("AS_IF", MobModsPacket.class, HealthPacket.class, VelocityPacket.class, KnockBackPacket.class, AirPacket.class);
 
         LOGGER = evt.getModLog();
+    
+        WailaRegistrar.preInit(evt);
     }
 
     @EventHandler

--- a/InfernalMobs/src/main/java/atomicstryker/infernalmobs/plugins/waila/PluginInfernalMobs.java
+++ b/InfernalMobs/src/main/java/atomicstryker/infernalmobs/plugins/waila/PluginInfernalMobs.java
@@ -1,0 +1,60 @@
+package atomicstryker.infernalmobs.plugins.waila;
+
+import atomicstryker.infernalmobs.common.InfernalMobsCore;
+import atomicstryker.infernalmobs.common.MobModifier;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaEntityAccessor;
+import mcp.mobius.waila.api.IWailaEntityProvider;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+
+public class PluginInfernalMobs implements IWailaEntityProvider {
+	
+	static IWailaEntityProvider INSTANCE = new PluginInfernalMobs();
+	
+	@Nonnull
+	@Override
+	public List<String> getWailaBody(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config) {
+		if (config.getConfig(WailaRegistrar.CONFIG_INFERNALMOBS_MODS, true) && entity instanceof EntityLiving) {
+			EntityLiving entityLiving = (EntityLiving) entity;
+			
+			// Check if entity has mods
+			if (InfernalMobsCore.getIsRareEntity(entityLiving)) {
+				// Get all mod names and add as single line to body tip
+				MobModifier mods = InfernalMobsCore.getMobModifiers(entityLiving);
+				String[] allMods = mods.getLinkedModName().split(" ");
+				
+				// Sort mods alphanumerically
+				Arrays.sort(allMods);
+				
+				if (config.getConfig(WailaRegistrar.CONFIG_INFERNALMOBS_LINEBREAK, true)) {
+					// If infernalmobs.linebreak was set true, add a linebreak if the line would
+					// exceed 40 characters with the next modifier name, given the line is not empty.
+					int maxChars = 40;
+					String currLine = "";
+					for (int i = 0; i < allMods.length; i++) {
+						String currMod = allMods[i];
+						if (currLine.length() > 0 && currLine.length() + currMod.length() > maxChars) {
+							currenttip.add(currLine);
+							currLine = "";
+						}
+						currLine = currLine.concat(currMod);
+						if (i + 1 < allMods.length)
+							currLine = currLine.concat(", ");
+					}
+					if (currLine.length() > 0)
+						currenttip.add(currLine);
+				} else {
+					// Otherwise just join the modifier names with a comma.
+					String modString = String.join(", ", allMods);
+					currenttip.add(modString);
+				}
+			}
+		}
+		return currenttip;
+	}
+}

--- a/InfernalMobs/src/main/java/atomicstryker/infernalmobs/plugins/waila/WailaRegistrar.java
+++ b/InfernalMobs/src/main/java/atomicstryker/infernalmobs/plugins/waila/WailaRegistrar.java
@@ -1,0 +1,29 @@
+package atomicstryker.infernalmobs.plugins.waila;
+
+import com.google.common.eventbus.Subscribe;
+import mcp.mobius.waila.api.IWailaRegistrar;
+import net.minecraft.entity.EntityLiving;
+import net.minecraftforge.fml.common.event.FMLInterModComms;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+public class WailaRegistrar {
+	
+	public static final String wailaModid = "waila";
+	
+	// Config entries
+	public static String CONFIG_INFERNALMOBS_MODS = "infernalmobs.mods";
+	public static String CONFIG_INFERNALMOBS_LINEBREAK = "infernalmobs.linebreak";
+	
+	@Subscribe
+	public static void preInit(FMLPreInitializationEvent event) {
+		FMLInterModComms.sendMessage(wailaModid, "register", "atomicstryker.infernalmobs.plugins.waila.WailaRegistrar.wailaCallback");
+	}
+	
+	public static void wailaCallback(IWailaRegistrar registrar) {
+		registrar.addConfig("infernalmobs", CONFIG_INFERNALMOBS_MODS, true);
+		registrar.addConfig("infernalmobs", CONFIG_INFERNALMOBS_LINEBREAK, true);
+		
+		// Register body provider
+		registrar.registerBodyProvider(PluginInfernalMobs.INSTANCE, EntityLiving.class);
+	}
+}


### PR DESCRIPTION
The implementation only adds the modifiers to the body of the WAILA
tooltip window, name pre- and suffixes need more work.

Changes:

 - Added Hwyla Plugin and Registrar classes. Registrar adds two options:
   - infernalmobs.mods: Toggle the plugin on/off.
   - infernalmobs.linebreak: Inserts linebreaks in the modifier listing
     if a line would exceed 40 characters.

- Added WailaRegistrar.preInit call to InfernalMobsCore.preinit.

- Added necessary Hwyla dependency and repository to build.gradle.

### Note:
I did this for myself but thought you might be interested. I could also port this to 1.14.x if need be.

Also, I have no idea why GitHub shows **1895** changes in InfernalMobsCore.java, I literally _added three lines_ one of which is blank. IntelliJ showed me two changes during the commit.

### Screenshot
With and without linebreak. (This is incidentally the mob from Issue #285, at two different points)
![HwylaPreview](https://user-images.githubusercontent.com/45288738/64014391-46489800-cb22-11e9-828d-1e1c63cc946b.png)