### PR TITLE
Fix separator, MP to SP edge case, curseforge request

### DIFF
--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_BattleTowersCore.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_BattleTowersCore.java
@@ -25,6 +25,7 @@ import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientConnectedToServerEvent;
@@ -240,6 +241,13 @@ public class AS_BattleTowersCore
         evt.registerServerCommand(new CommandRegenerateBattleTower());
         evt.registerServerCommand(new CommandRegenerateAllBattleTowers());
         evt.registerServerCommand(new CommandDeleteAllBattleTowers());
+    }
+    
+    @EventHandler
+    public void serverStopped(FMLServerStoppedEvent evt)
+    {
+    	//Wipe world handles to avoid save folder conflicts
+    	WorldGenHandler.wipeWorldHandles();
     }
 
     public void loadForgeConfig()

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_BattleTowersCore.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/AS_BattleTowersCore.java
@@ -29,6 +29,7 @@ import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedInEvent;
 import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientConnectedToServerEvent;
+import net.minecraftforge.fml.common.network.FMLNetworkEvent.ClientDisconnectionFromServerEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry.ObjectHolder;
@@ -109,6 +110,13 @@ public class AS_BattleTowersCore
     {
         System.out.println(FMLCommonHandler.instance().getEffectiveSide() + " registered ClientConnectedToServerEvent, sending packet to server");
         networkHelper.sendPacketToServer(new LoginPacket());
+    }
+
+    @SubscribeEvent
+    public void onClientDisconnected(ClientDisconnectionFromServerEvent event)
+    {
+        //Tell the client's WorldGenHandler to clear the world map on the next world load
+        WorldGenHandler.shouldClearWorldMap = true;
     }
 
     @SubscribeEvent

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/WorldGenHandler.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/WorldGenHandler.java
@@ -34,6 +34,7 @@ public class WorldGenHandler implements IWorldGenerator
     private HashMap<String, Boolean> biomesMap;
     private HashMap<String, Boolean> providerMap;
     private final static Map<Integer, WorldHandle> worldMap = new HashMap<>();
+    public static boolean shouldClearWorldMap = false;
 
     private final AS_WorldGenTower generator;
 
@@ -63,6 +64,12 @@ public class WorldGenHandler implements IWorldGenerator
     @SubscribeEvent
     public void eventWorldLoad(WorldEvent.Load evt)
     {
+        if(shouldClearWorldMap)
+        {
+            wipeWorldHandles();
+            shouldClearWorldMap = false;
+        }
+
         WorldHandle wh = getWorldHandle(evt.getWorld());
         if (!wh.posFileLoaded)
         {
@@ -83,7 +90,7 @@ public class WorldGenHandler implements IWorldGenerator
             {
                 String dim_folder = "";
                 if (dimension != 0)
-                    dim_folder = File.pathSeparator + world.provider.getSaveFolder();
+                    dim_folder = File.separator + world.provider.getSaveFolder();
                 try
                 {
                     result.worldSaveDirectory = new File(world.getSaveHandler().getWorldDirectory().getCanonicalPath() + dim_folder);

--- a/BattleTowers/src/main/java/atomicstryker/battletowers/common/WorldGenHandler.java
+++ b/BattleTowers/src/main/java/atomicstryker/battletowers/common/WorldGenHandler.java
@@ -54,6 +54,11 @@ public class WorldGenHandler implements IWorldGenerator
         boolean towerPositionsAccessLock;
         int disableGenerationHook;
     }
+    
+    public static void wipeWorldHandles()
+    {
+    	worldMap.clear();
+    }
 
     @SubscribeEvent
     public void eventWorldLoad(WorldEvent.Load evt)
@@ -74,6 +79,21 @@ public class WorldGenHandler implements IWorldGenerator
         {
             result = new WorldHandle();
             result.worldSaveDirectory = world.getSaveHandler().getWorldDirectory();
+            if(result.worldSaveDirectory!=null)
+            {
+            	String dim_folder = "";
+            	if(dimension!=0) dim_folder = "\\"+world.provider.getSaveFolder();
+            	try
+            	{
+            		result.worldSaveDirectory = new File (world.getSaveHandler().getWorldDirectory().getCanonicalPath()+dim_folder);
+            	} 
+            	catch (IOException e) 
+            	{
+            		//Failed, revert to old handling for safety
+            		result.worldSaveDirectory = world.getSaveHandler().getWorldDirectory();
+            		e.printStackTrace();
+            	}
+            }
             result.posFileLoaded = false;
             result.towerPositionsAccessLock = false;
             result.disableGenerationHook = 0;


### PR DESCRIPTION
Apparently pathSeparator is for separating 'PATH' values, that one caught me off guard.

Also a fix for an edge case where if you play multiplayer then singleplayer, the worldhandles still don't get cleared, causing writes to the root modpack folder. 

I tested this branch as best I could on single and multi, and it appears to be working fine.
(also I tried to get the formatting right, hope it worked)

Could you update the 1.12.2 BattleTowers on curseforge with this? I'm pretty sure the pack RLCraft is planning on updating soon, and BattleTowers has a large presence in it.