### PR TITLE
[Ruins] reinstate old preserveBlock functionality, et al. (issue #303)

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuleStringNbtHelper.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuleStringNbtHelper.java
@@ -1,15 +1,15 @@
 package atomicstryker.ruins.common;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.JsonToNBT;
 import net.minecraft.nbt.NBTUtil;
 import net.minecraft.tileentity.TileEntity;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class RuleStringNbtHelper {
 
@@ -17,73 +17,86 @@ public class RuleStringNbtHelper {
     public static String StringFromBlockState(BlockState blockState, TileEntity tileEntity) {
         CompoundNBT tagCompound = NBTUtil.writeBlockState(blockState);
         if (tileEntity != null) {
+            CompoundNBT parameters = new CompoundNBT();
             CompoundNBT tagTileEntity = tileEntity.write(new CompoundNBT());
-            tagCompound.put("ruinsTE", tagTileEntity);
+            tagTileEntity.remove("id");
+            tagTileEntity.remove("x");
+            tagTileEntity.remove("y");
+            tagTileEntity.remove("z");
+            parameters.put("entity", tagTileEntity);
+            tagCompound.put("Ruins", parameters);
         }
         return tagCompound.toString();
     }
 
-    public static BlockState blockStateFromString(String input) {
-        CompoundNBT nbtTagCompound;
-        try {
-            nbtTagCompound = JsonToNBT.getTagFromJson(input);
-        } catch (CommandSyntaxException e) {
-            RuinsMod.LOGGER.error("failed to parse block state " + input, e);
-            return Blocks.AIR.getDefaultState();
-        }
+    public static BlockState blockStateFromCompound(CompoundNBT input) {
+        CompoundNBT nbtTagCompound = input.copy();
         // strip this away here
-        if (nbtTagCompound.contains("ruinsTE")) {
-            nbtTagCompound.remove("ruinsTE");
-        }
+        nbtTagCompound.remove("ruinsTE");
         return NBTUtil.readBlockState(nbtTagCompound);
     }
 
-    public static CompoundNBT tileEntityNBTFromString(String input, int x, int y, int z) {
-        CompoundNBT nbtTagCompound;
-        try {
-            nbtTagCompound = JsonToNBT.getTagFromJson(input);
-        } catch (CommandSyntaxException e) {
-            return null;
+    public static CompoundNBT tileEntityNBTFromCompound(CompoundNBT defaultValue, CompoundNBT input) {
+        CompoundNBT teNbt = defaultValue;
+        if (input.contains("ruinsTE", 10)) {
+            RuinsMod.LOGGER.warn("{ruinsTE:{...}} is deprecated; use {Ruins:{entity:{...}}} instead");
+            if (defaultValue == null) {
+                teNbt = input.getCompound("ruinsTE").copy();
+                teNbt.remove("id");
+                teNbt.remove("x");
+                teNbt.remove("y");
+                teNbt.remove("z");
+            }
         }
-        if (nbtTagCompound.contains("ruinsTE")) {
-            CompoundNBT teNbt = nbtTagCompound.getCompound("ruinsTE");
-            teNbt.putInt("x", x);
-            teNbt.putInt("y", y);
-            teNbt.putInt("z", z);
-            return teNbt;
-        }
-        return null;
+        return teNbt;
     }
 
-    // assuming we can have multiple blockstates {nbt}{nbt}{nbt}, split them into a string array. a normal rule will have 1
-    public static String[] splitRuleByBrackets(String rule) {
-        List<String> result = new ArrayList<>();
+    // assuming we can have multiple blockstates {nbt}{nbt}{nbt}, split them into a TAG_Compound list. a normal rule will have 1
+    public static List<CompoundNBT> splitRuleByBrackets(String rule) {
+        List<CompoundNBT> result = new ArrayList<>();
         int currentBracketStartIndex = 0;
         int bracketCounter = 0;
+        char quote = 0;
         for (int i = 0; i < rule.length(); i++) {
-            if ('{' == rule.charAt(i)) {
+            char c = rule.charAt(i);
+            if (quote != 0) {
+                if (quote == c) {
+                    quote = 0;
+                } else if ('\\' == c) {
+                    ++i;
+                }
+            } else if ('{' == c) {
                 bracketCounter++;
                 if (bracketCounter == 1) {
                     currentBracketStartIndex = i;
                 }
-            } else if ('}' == rule.charAt(i)) {
+            } else if ('}' == c) {
                 bracketCounter--;
                 if (bracketCounter < 0) {
                     RuinsMod.LOGGER.error("Error in rule {} at character {}: unbalanced brackets!", rule, i);
                     return null;
                 } else if (bracketCounter == 0) {
-                    result.add(rule.substring(currentBracketStartIndex, i + 1));
+                    CompoundNBT nbtTagCompound;
+                    try {
+                        nbtTagCompound = JsonToNBT.getTagFromJson(rule.substring(currentBracketStartIndex, i + 1));
+                    } catch (CommandSyntaxException e) {
+                        RuinsMod.LOGGER.error("Error in rule {} starting at character {}: unbalanced brackets!", rule, currentBracketStartIndex);
+                        return null;
+                    }
+                    result.add(nbtTagCompound);
                 }
+            } else if ('"' == c || '\'' == c) {
+                quote = c;
             }
+        }
+        if (quote != 0) {
+            RuinsMod.LOGGER.error("Error in rule {} unbalanced quotes!", rule);
+            return null;
         }
         if (bracketCounter > 0) {
             RuinsMod.LOGGER.error("Error in rule {} unbalanced brackets!", rule);
             return null;
         }
-        String[] output = new String[result.size()];
-        for (int i = 0; i < output.length; i++) {
-            output[i] = result.get(i);
-        }
-        return output;
+        return result;
     }
 }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/World2TemplateParser.java
@@ -1,6 +1,16 @@
 package atomicstryker.ruins.common;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.google.common.collect.ImmutableList;
+
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
@@ -14,15 +24,6 @@ import net.minecraft.util.text.TranslationTextComponent;
 import net.minecraft.world.World;
 import net.minecraft.world.storage.loot.LootTables;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.PrintWriter;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
-
 class World2TemplateParser extends Thread {
 
     /**
@@ -31,7 +32,7 @@ class World2TemplateParser extends Thread {
      * templates.
      */
     private final BlockData templateHelperBlock;
-    private final BlockData nothing = new BlockData(Blocks.AIR.getDefaultState(), 0, null);
+    private final BlockData nothing = new BlockData(Blocks.AIR.getDefaultState(), null);
 
     private final List<String> chestLootTableNamesToGenerate = ImmutableList.of(
             LootTables.CHESTS_SIMPLE_DUNGEON.toString(), LootTables.CHESTS_BURIED_TREASURE.toString(),
@@ -92,7 +93,7 @@ class World2TemplateParser extends Thread {
         z = c;
         fileName = fName;
         BlockState state = world.getBlockState(new BlockPos(a, b, c));
-        templateHelperBlock = new BlockData(state, 0, null);
+        templateHelperBlock = new BlockData(state, null);
         usedBlocks = new ArrayList<>();
         layerData = new ArrayList<>();
     }
@@ -190,7 +191,6 @@ class World2TemplateParser extends Thread {
 
                     BlockPos pos = new BlockPos(blockx, blocky, blockz);
                     temp.blockState = world.getBlockState(pos);
-                    temp.spawnRule = 0;
                     temp.tileEntity = world.getTileEntity(pos);
 
                     if (temp.blockState.getBlock() == Blocks.AIR || temp.equals(templateHelperBlock)) {
@@ -378,17 +378,15 @@ class World2TemplateParser extends Thread {
 
     private class BlockData {
         BlockState blockState;
-        int spawnRule;
         TileEntity tileEntity;
 
-        BlockData(BlockState state, int sr, TileEntity te) {
+        BlockData(BlockState state, TileEntity te) {
             blockState = state;
-            spawnRule = sr;
             tileEntity = te;
         }
 
         BlockData copy() {
-            return new BlockData(blockState, spawnRule, tileEntity);
+            return new BlockData(blockState, tileEntity);
         }
 
         boolean matchesBlock(World w, int x, int y, int z) {
@@ -397,7 +395,7 @@ class World2TemplateParser extends Thread {
 
         @Override
         public String toString() {
-            return String.format("%s,100,%s", spawnRule, RuleStringNbtHelper.StringFromBlockState(blockState, tileEntity));
+            return String.format("%s", RuleStringNbtHelper.StringFromBlockState(blockState, tileEntity));
         }
 
         @Override

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -579,3 +579,16 @@ a: setAccessible now true
 
 1.14.4.4
 + fix template parser not reading tile entities (chests contents, signs etc)
+
+1.14.4.5 (pending)
++ fixed NBT parsing to correctly handle braces within quoted strings
++ restored old "preserveBlock" directive--now {Name:"ruins:null"} pseudoblock
++ default rule0 changed from "minecraft:air" to "ruins:null"
++ added tag for Ruins-specific block parameter specs--{Ruins:{},...}
++ restored old block weight (e.g., 2.5*dirt) feature--now {Ruins:{weight:2.5},...}
++ restored old "addbonemeal" feature--now {Ruins:{bonemeal:1},...}
++ enhanced bonemeal feature; can be >1 for extra fertilization goodness
++ moved block entity spec from {ruinsTE:{},...} to {Ruins:{entity:{}},...}
++ deprecated "ruinsTE" tag; still supported, but emits warning to log
++ /parseruin updated to generate rules as per current format
++ block entities no longer require "id" tag


### PR DESCRIPTION
These changes introduce a new pseudo-block--**ruins:null**--for use in rules. It functions as the old **preserveBlock** did, leaving the existing block at its location intact. The default rule0 is now defined as **ruins:null** instead of **minecraft:air**. Example, this rule3 is 50% cobble, 50% nuthin':
`rule3={Name:"cobblestone"}{Name:"ruins:null"}`

I also added a new tag--"Ruins"--to hold all Ruins-specific block parameters, as well as implementations for three such parameters: "weight", "bonemeal", and "entity". Example, this rule5 is 70% oak sapling, 10% fertilized birch sapling (many of which are grown into trees), and 20% spruce sign:
`rule5={Name:"oak_sapling",Ruins:{weight:3.5}}{Name:"birch_sapling",Ruins:{weight:.5,bonemeal:1}}{Name:"spruce_sign",Ruins:{entity:{Text2:"\"Ceci n'est pas\"",Text3:"\"un arbre.\""}}}`

All, some, or none of these parameters may be specified for a particular block. "weight" functions as it did in 1.12, defaulting to 1; it doesn't have to be an integer, but it can't be negative. "bonemeal" functions as the old "-addbonemeal" suffix, except you can now smack that sucker with multiple bonemeals by specifying a number greater than 1; it can't be negative, and defaults to 0. "entity" is a replacement for "ruinsTE", bringing all the Ruins parameters under one easily-extensible umbrella. However, "ruinsTE" is still supported as before, though it's deprecated.

Also: NBT parsing was fixed to properly handle braces within quoted strings, and block entity specifications no longer require an "id" tag (as seen in example rule5, above).

What I _didn't_ do was implement the foreground/background thing. I'll wait to see if there's any demand for it.
