### PR TITLE
[Ruins] address user feedback (#318)

### DIFF
--- a/Ruins/build.gradle
+++ b/Ruins/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
 def mcversion = '1.15.1'
-version = '1.15.1.1'
+version = '1.15.1.2'
 group = 'atomicstryker.ruins'
 archivesBaseName = 'ruins'
 

--- a/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/CommandTestTemplate.java
@@ -89,7 +89,7 @@ class CommandTestTemplate {
                         for (y = ceiling - 1; y > 7; y--) {
                             BlockPos pos = new BlockPos(x, y, z);
                             final BlockState b = world.getBlockState(pos);
-                            if (parsedRuin.isIgnoredBlock(b, world, pos)) {
+                            if (parsedRuin.isIgnoredBlock(b)) {
                                 continue;
                             }
 

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinGenerator.java
@@ -249,7 +249,7 @@ class RuinGenerator {
                     return -1;
                 }
                 final BlockState b = world.getBlockState(pos);
-                if (r.isIgnoredBlock(b, world, pos)) {
+                if (r.isIgnoredBlock(b)) {
                     continue;
                 }
 
@@ -276,7 +276,7 @@ class RuinGenerator {
                         // now find the first non-air block from here
                         for (; y > -1; y--) {
                             BlockPos pos = new BlockPos(x, y, z);
-                            if (!r.isIgnoredBlock(world.getBlockState(pos), world, pos)) {
+                            if (!r.isIgnoredBlock(world.getBlockState(pos))) {
                                 if (r.isAcceptableSurface(b)) {
                                     return y + 1;
                                 }
@@ -294,7 +294,7 @@ class RuinGenerator {
                         return -1;
                     }
                     final BlockState b = world.getBlockState(pos);
-                    if (!r.isIgnoredBlock(b, world, pos)) {
+                    if (!r.isIgnoredBlock(b)) {
                         accept = r.isAcceptableSurface(b);
                     } else {
                         return accept ? y : -1;

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuleStringNbtHelper.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuleStringNbtHelper.java
@@ -3,6 +3,8 @@ package atomicstryker.ruins.common;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.Level;
+
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.block.BlockState;
@@ -12,7 +14,7 @@ import net.minecraft.nbt.NBTUtil;
 import net.minecraft.tileentity.TileEntity;
 
 public class RuleStringNbtHelper {
-
+    private static int throttleEntityWarning = 4;
 
     public static String StringFromBlockState(BlockState blockState, TileEntity tileEntity) {
         CompoundNBT tagCompound = NBTUtil.writeBlockState(blockState);
@@ -39,7 +41,12 @@ public class RuleStringNbtHelper {
     public static CompoundNBT tileEntityNBTFromCompound(CompoundNBT defaultValue, CompoundNBT input) {
         CompoundNBT teNbt = defaultValue;
         if (input.contains("ruinsTE", 10)) {
-            RuinsMod.LOGGER.warn("{ruinsTE:{...}} is deprecated; use {Ruins:{entity:{...}}} instead");
+            // emit a few deprecation warnings, then demote to debug
+            final Level level = throttleEntityWarning > 0 ? Level.WARN : Level.DEBUG;
+            RuinsMod.LOGGER.log(level, "{ruinsTE:{...}} is deprecated; use {Ruins:{entity:{...}}} instead");
+            if (throttleEntityWarning > 0 && --throttleEntityWarning < 1) {
+                RuinsMod.LOGGER.warn("suppressing ruinsTE deprecation warnings; limit reached");
+            }
             if (defaultValue == null) {
                 teNbt = input.getCompound("ruinsTE").copy();
                 teNbt.remove("id");

--- a/Ruins/src/main/resources/META-INF/mods.toml
+++ b/Ruins/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[25,)" #mandatory (24 is current forge version)
+loaderVersion="[30,)" #mandatory (30 is current forge version)
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/AtomicStryker/atomicstrykers-minecraft-mods/issues" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
@@ -14,7 +14,7 @@ issueTrackerURL="https://github.com/AtomicStryker/atomicstrykers-minecraft-mods/
 # The modid of the mod
 modId="ruins" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
-version="1.14.3.3" #mandatory
+version="${file.jarVersion}" #mandatory
  # A display name for the mod
 displayName="Ruins" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification <here>
@@ -22,7 +22,7 @@ updateJSONURL="http://www.atomicstryker.net/updatemanager/ruins.json" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
 displayURL="http://atomicstryker.org/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
-logoFile="examplemod.png" #optional
+# logoFile="examplemod.png" #optional
 # A text field displayed in the mod UI
 credits="by AtomicStryker et al" #optional
 # A text field displayed in the mod UI
@@ -32,13 +32,13 @@ description='''
 Ruins mod description TODO, just copy it from a website or something.
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.examplemod]] #optional
+[[dependencies.ruins]] #optional
     # the modid of the dependency
     modId="forge" #mandatory
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[25,)" #mandatory
+    versionRange="[30,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -599,3 +599,4 @@ a: setAccessible now true
 
 1.15.1.2
 + fix version id displayed in main menu gui
++ limit ruinsTE deprecation warnings (4 max) to avoid log spam

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -600,3 +600,4 @@ a: setAccessible now true
 1.15.1.2
 + fix version id displayed in main menu gui
 + limit ruinsTE deprecation warnings (4 max) to avoid log spam
++ properly ignore leaves and grass and stuff

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -596,3 +596,6 @@ a: setAccessible now true
 
 1.15.1.1
 + ported to minecraft 1.15.1
+
+1.15.1.2
++ fix version id displayed in main menu gui


### PR DESCRIPTION
In issue #318 , Gbergz describes an overabundance of **ruinsTE** deprecation warnings in the log file. The number of warnings is now capped at 4; subsequent notifications are sent to the debug log only. I think it's appropriate to still flag _every_ occurrence in the debug log, as that's what the debug log is for, but the general log is more useful without the clutter.

In [Minecraft Forum](https://www.minecraftforum.net/forums/mapping-and-modding-java-edition/minecraft-mods/1282339-1-15-1-ruins-structure-spawning-system?comment=4733), argonz mentions ruins spawning in trees. While there are workarounds, the intended functionality which would avoid the problem is broken. During the 1.13.2 migration, Block.isFoliage() was introduced as a way to check for ignorable plant blocks. This is a Forge extension which--at least in 1.15.1--isn't implemented for any vanilla blocks. As a result, only air, snow, and cobwebs were ignored. Now the check is based on block materials and properly recognizes plants and leaves.