### PR TITLE
[Ruins]Fix an issue that prevent loot tables from mods being used.

### DIFF
--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -606,10 +606,7 @@ public class RuinTemplateRule
         else if (dataString.startsWith("ChestGenHook:"))
         {
             String[] s = dataString.split(":");
-            if(s.length > 3){
-                s[1] = String.join(":", s[1], s[2]);
-                s[2] = s[3];
-            }
+            if(s.length > 3) s[1] = String.join(":", s[1], s[2]);
             int targetCount = s.length > 2 ? Integer.valueOf(s[s.length-1].split("-")[0]) : 0;
             addChestGenChest(world, random, x, y, z, s[1], targetCount, blocknum, rotate);
         }

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -606,7 +606,7 @@ public class RuinTemplateRule
         else if (dataString.startsWith("ChestGenHook:"))
         {
             String[] s = dataString.split(":");
-            int targetCount = s.length > 1 ? Integer.valueOf(s[s.length-2].split("-")[0]) : 0;
+            int targetCount = s.length > 2 ? Integer.valueOf(s[s.length-2].split("-")[0]) : 0;
             addChestGenChest(world, random, x, y, z, s[1], targetCount, blocknum, rotate);
         }
         else if (dataString.startsWith("IInventory;"))

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -606,7 +606,7 @@ public class RuinTemplateRule
         else if (dataString.startsWith("ChestGenHook:"))
         {
             String[] s = dataString.split(":");
-            int targetCount = s.length > 2 ? Integer.valueOf(s[s.length-2].split("-")[0]) : 0;
+            int targetCount = s.length > 2 ? Integer.valueOf(s[s.length-1].split("-")[0]) : 0;
             addChestGenChest(world, random, x, y, z, s[1], targetCount, blocknum, rotate);
         }
         else if (dataString.startsWith("IInventory;"))

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -607,7 +607,8 @@ public class RuinTemplateRule
         {
             String[] s = dataString.split(":");
             int targetCount = s.length > 2 ? Integer.valueOf(s[s.length-1].split("-")[0]) : 0;
-            addChestGenChest(world, random, x, y, z, s[1], targetCount, blocknum, rotate);
+            String lootTable = s.length > 3 ? s[1]+s[2] : s[1];
+            addChestGenChest(world, random, x, y, z, lootTable, targetCount, blocknum, rotate);
         }
         else if (dataString.startsWith("IInventory;"))
         {

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -606,9 +606,12 @@ public class RuinTemplateRule
         else if (dataString.startsWith("ChestGenHook:"))
         {
             String[] s = dataString.split(":");
+            if(s.length > 3){
+                s[1] = String.join(":", s[1], s[2]);
+                s[2] = s[3];
+            }
             int targetCount = s.length > 2 ? Integer.valueOf(s[s.length-1].split("-")[0]) : 0;
-            String lootTable = s.length > 3 ? s[1]+s[2] : s[1];
-            addChestGenChest(world, random, x, y, z, lootTable, targetCount, blocknum, rotate);
+            addChestGenChest(world, random, x, y, z, s[1], targetCount, blocknum, rotate);
         }
         else if (dataString.startsWith("IInventory;"))
         {

--- a/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
+++ b/Ruins/src/main/java/atomicstryker/ruins/common/RuinTemplateRule.java
@@ -606,7 +606,7 @@ public class RuinTemplateRule
         else if (dataString.startsWith("ChestGenHook:"))
         {
             String[] s = dataString.split(":");
-            int targetCount = s.length > 1 ? Integer.valueOf(s[2].split("-")[0]) : 0;
+            int targetCount = s.length > 1 ? Integer.valueOf(s[s.length-2].split("-")[0]) : 0;
             addChestGenChest(world, random, x, y, z, s[1], targetCount, blocknum, rotate);
         }
         else if (dataString.startsWith("IInventory;"))


### PR DESCRIPTION
```
String[] s = dataString.split(":");
int targetCount = s.length > 1 ? Integer.valueOf(s[2].split("-")[0]) : 0;
```
This block of codes produces
```
[19:52:38] [Server thread/INFO] [STDERR]: [atomicstryker.ruins.common.RuinTemplate:doBuild:336]: java.lang.NumberFormatException: For input string: "chests/chestloot1"
[19:52:38] [Server thread/INFO] [STDERR]: [atomicstryker.ruins.common.RuinTemplate:doBuild:336]: 	at java.lang.NumberFormatException.forInputString(Unknown Source)
[19:52:38] [Server thread/INFO] [STDERR]: [atomicstryker.ruins.common.RuinTemplate:doBuild:336]: 	at java.lang.Integer.parseInt(Unknown Source)
[19:52:38] [Server thread/INFO] [STDERR]: [atomicstryker.ruins.common.RuinTemplate:doBuild:336]: 	at java.lang.Integer.valueOf(Unknown Source)
[19:52:38] [Server thread/INFO] [STDERR]: [atomicstryker.ruins.common.RuinTemplate:doBuild:336]: 	at atomicstryker.ruins.common.RuinTemplateRule.doSpecialBlock(RuinTemplateRule.java:609)
```
when `ChestGenHook:neuroflow:chests/chestloot1:5-3` is parsed.