### PR TITLE
[Ruins] (1.15.2) account for nonatomic position file deletion (issue #348)

### DIFF
--- a/Ruins/build.gradle
+++ b/Ruins/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
 def mcversion = '1.15.2'
-version = '1.15.2.1'
+version = '1.15.2.2'
 group = 'atomicstryker.ruins'
 archivesBaseName = 'ruins'
 

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -612,3 +612,4 @@ a: setAccessible now true
 + put zombies on pirate ships; drowned don't spawn above sea level
 
 1.15.2.2
++ account for nonatomic position file deletion

--- a/Ruins/src/main/resources/changelog.txt
+++ b/Ruins/src/main/resources/changelog.txt
@@ -610,3 +610,5 @@ a: setAccessible now true
 + ported to Minecraft 1.15.2 (Forge 31.2.0)
 + don't be a coremod; install pseudo-feature instead
 + put zombies on pirate ships; drowned don't spawn above sea level
+
+1.15.2.2


### PR DESCRIPTION
I can't duplicate the problem identified by Traktool in issue #348 myself, but I think I know what's going on. Ruins periodically creates a new position file, deletes the current one, and renames the new one to become the current one. Trouble is, file deletion isn't atomic, so the delete may not be complete by the time of the rename (under Windows, especially), and the rename fails. I now first rename the current file and then delete _that_, avoiding the possibility of a name conflict.

Since I can't reproduce the problem, I can't test to see if it's solved; I'll need to rely on Traktool to test it. I can test to make sure this change does no harm, though, and I have. I also softened the log message to say "fail" instead of "crash," as Ruins wasn't really crashing.