### PR TITLE
[1.15.1] Fixes an issue in findercompass.cfg file path on MacOS.

### DIFF
--- a/FinderCompass/src/main/java/atomicstryker/findercompass/common/FinderCompassMod.java
+++ b/FinderCompass/src/main/java/atomicstryker/findercompass/common/FinderCompassMod.java
@@ -58,7 +58,7 @@ public class FinderCompassMod {
     public void preInit(FMLCommonSetupEvent evt) {
         compassConfig = createDefaultConfig();
         try {
-            compassConfig = GsonConfig.loadConfigWithDefault(CompassConfig.class, new File(proxy.getMcFolder(), File.separator + "config" + File.separator + "findercompass.cfg"), compassConfig);
+            compassConfig = GsonConfig.loadConfigWithDefault(CompassConfig.class, new File(proxy.getMcFolder() + File.separator + "config" + File.separator, "findercompass.cfg"), compassConfig);
             loadSettingListFromConfig(compassConfig);
         } catch (IOException e) {
             LOGGER.error("IOException parsing config", e);


### PR DESCRIPTION
Hello,

On MacOS, the findercompass.fcg file is stored in the minecraft folder and is named "/config/findercompass.cfg".
I fixed the issue by moving the "/config/" path fragment to the first parameter of File constructor.