### PR TITLE
Enable light-level feature and support item tags

### DIFF
--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLightSourceContainer.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLightSourceContainer.java
@@ -6,6 +6,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.Map;
 
@@ -46,7 +47,7 @@ public class DynamicLightSourceContainer {
             BlockPos nextPos = findNewCurLightPos(ent.level);
             if (nextPos != null && !nextPos.equals(activeLightPos)) {
                 removeLight(ent.level);
-                addLight(ent.level, nextPos);
+                addLight(ent.level, nextPos, lightSource.getLightLevel());
             }
             // note: if no new position can be found, the light will actually remain active at the previous position
         }
@@ -118,13 +119,13 @@ public class DynamicLightSourceContainer {
         return null;
     }
 
-    private void addLight(Level world, BlockPos nextPos) {
+    private void addLight(Level world, BlockPos nextPos, int lightLevel) {
         // add light block on for which we already determined substitution is possible
         BlockState blockState = world.getBlockState(nextPos);
         Block currentBlock = blockState.getBlock();
         for (Map.Entry<Block, Block> vanillaBlockToLitBlockEntry : DynamicLights.vanillaBlocksToLitBlocksMap.entrySet()) {
             if (currentBlock.equals(vanillaBlockToLitBlockEntry.getKey())) {
-                world.setBlock(nextPos, vanillaBlockToLitBlockEntry.getValue().defaultBlockState(), 3);
+                world.setBlock(nextPos, vanillaBlockToLitBlockEntry.getValue().defaultBlockState().setValue(BlockStateProperties.POWER, lightLevel), 3);
                 // schedule a block tick 5 seconds into the future, as fallback for the block to clean itself up
                 world.scheduleTick(nextPos, vanillaBlockToLitBlockEntry.getValue(), 150);
                 activeLightPos.set(nextPos);

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLights.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLights.java
@@ -7,6 +7,9 @@ import atomicstryker.dynamiclights.server.modules.DroppedItemsLightSource;
 import atomicstryker.dynamiclights.server.modules.PlayerSelfLightSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.SimplePreparableReloadListener;
+import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -15,6 +18,7 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.Material;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
@@ -99,6 +103,24 @@ public class DynamicLights {
         if (config == null) {
             initConfig();
         }
+    }
+
+    @SubscribeEvent
+    public void onAddReloadListener(AddReloadListenerEvent event) {
+        // we need to clear our item -> light level cache on reload
+        LOGGER.debug("Adding reload listener for light level cache");
+        event.addListener(new SimplePreparableReloadListener() {
+
+            @Override
+            protected Object prepare(ResourceManager p_10796_, ProfilerFiller p_10797_) {
+                return null;
+            }
+
+            @Override
+            protected void apply(Object p_10793_, ResourceManager p_10794_, ProfilerFiller p_10795_) {
+                ItemLightLevels.clearCache();
+            }
+        });
     }
 
     private void initConfig() {

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLights.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLights.java
@@ -11,6 +11,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.level.material.Material;
 import net.minecraftforge.common.MinecraftForge;
@@ -81,11 +82,11 @@ public class DynamicLights {
 
     @SubscribeEvent
     public static void onBlocksRegistration(final RegistryEvent.Register<Block> event) {
-        Block litAirBlock = new BlockLitAir(BlockBehaviour.Properties.of(Material.AIR).noCollission().randomTicks().lightLevel((x) -> 15).noDrops().air()).setRegistryName(DynamicLights.MOD_ID, "lit_air");
+        Block litAirBlock = new BlockLitAir(BlockBehaviour.Properties.of(Material.AIR).noCollission().randomTicks().lightLevel((x) -> x.getValue(BlockStateProperties.POWER)).noDrops().air()).setRegistryName(DynamicLights.MOD_ID, "lit_air");
         event.getRegistry().register(litAirBlock);
-        Block litWaterBlock = new BlockLitWater(Fluids.WATER, BlockBehaviour.Properties.of(Material.WATER).noCollission().strength(100.0F).lightLevel((x) -> 15).noDrops()).setRegistryName(DynamicLights.MOD_ID, "lit_water");
+        Block litWaterBlock = new BlockLitWater(Fluids.WATER, BlockBehaviour.Properties.of(Material.WATER).noCollission().strength(100.0F).lightLevel((x) -> x.getValue(BlockStateProperties.POWER)).noDrops()).setRegistryName(DynamicLights.MOD_ID, "lit_water");
         event.getRegistry().register(litWaterBlock);
-        Block litCaveAirBlock = new BlockLitCaveAir(BlockBehaviour.Properties.of(Material.AIR).noCollission().lightLevel((x) -> 15).noDrops().air()).setRegistryName(DynamicLights.MOD_ID, "lit_cave_air");
+        Block litCaveAirBlock = new BlockLitCaveAir(BlockBehaviour.Properties.of(Material.AIR).noCollission().lightLevel((x) -> x.getValue(BlockStateProperties.POWER)).noDrops().air()).setRegistryName(DynamicLights.MOD_ID, "lit_cave_air");
         event.getRegistry().register(litCaveAirBlock);
         vanillaBlocksToLitBlocksMap.put(Blocks.AIR, litAirBlock);
         vanillaBlocksToLitBlocksMap.put(Blocks.WATER, litWaterBlock);

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/ItemConfigHelper.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/ItemConfigHelper.java
@@ -52,7 +52,7 @@ public class ItemConfigHelper {
     }
 
     public static String fromItemStack(ItemStack itemStack, int lightLevel) {
-        var resultTag = itemStack.getOrCreateTag();
+        CompoundTag resultTag = itemStack.getOrCreateTag();
         resultTag.putString("nameId", ForgeRegistries.ITEMS.getKey(itemStack.getItem()).toString());
         if(lightLevel > 0) {
             resultTag.putShort("lightLevel", (short) lightLevel);
@@ -65,8 +65,8 @@ public class ItemConfigHelper {
             return 0;
         }
 
-        for (var entry : itemStackList.entrySet()) {
-            var is = entry.getKey();
+        for (Map.Entry<ItemStack, Integer> entry : itemStackList.entrySet()) {
+            ItemStack is = entry.getKey();
             if (is.getItem() == stack.getItem() && ItemStack.tagMatches(is, stack)) {
                 return entry.getValue();
             }

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/ItemLightLevels.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/ItemLightLevels.java
@@ -1,0 +1,49 @@
+package atomicstryker.dynamiclights.server;
+
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ItemLightLevels {
+	private static final Logger LOGGER = LogManager.getLogger();
+	private static Map<String, Map<Item, Integer>> cache = new HashMap<>();
+
+	public static void clearCache() {
+		LOGGER.info("Clearing item tag to light level mapping cache");
+		cache.clear();
+	}
+
+	public static int getLightFromItemStack(ItemStack stack, String tagName) {
+		if(stack == null || stack.isEmpty()) {
+			return 0;
+		}
+
+		var innerCache = cache.computeIfAbsent(tagName, s -> new HashMap<>());
+
+		// 1.18.2: return innerCache.computeIfAbsent(stack.getItem(), item1 -> stack.getTags().map(t -> getLightLevelByTagName(t.location().toString(), tagName)).filter(t -> t > 0 && t <= 15).max(Integer::compareTo).orElse(0));
+		return innerCache.computeIfAbsent(stack.getItem(), item1 -> stack.getItem().getTags().stream().map(t -> getLightLevelByTagName(t.toString(), tagName)).filter(t -> t > 0 && t <= 15).max(Integer::compareTo).orElse(0));
+	}
+
+	private static int getLightLevelByTagName(String testee, String tagName) {
+		var prefix = DynamicLights.MOD_ID + ":" + tagName;
+		if(!testee.startsWith(prefix)) {
+			return 0;
+		}
+
+		if(testee.equals(prefix)) {
+			return 15;
+		}
+
+		int level = 0;
+		try {
+			var suffix = testee.substring(prefix.length()+1);
+			level = Integer.parseInt(suffix);
+		} catch (Exception ignored) {}
+
+		return level;
+	}
+}

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/ItemLightLevels.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/ItemLightLevels.java
@@ -22,14 +22,14 @@ public class ItemLightLevels {
 			return 0;
 		}
 
-		var innerCache = cache.computeIfAbsent(tagName, s -> new HashMap<>());
+		Map<Item, Integer> innerCache = cache.computeIfAbsent(tagName, s -> new HashMap<>());
 
 		// 1.18.2: return innerCache.computeIfAbsent(stack.getItem(), item1 -> stack.getTags().map(t -> getLightLevelByTagName(t.location().toString(), tagName)).filter(t -> t > 0 && t <= 15).max(Integer::compareTo).orElse(0));
 		return innerCache.computeIfAbsent(stack.getItem(), item1 -> stack.getItem().getTags().stream().map(t -> getLightLevelByTagName(t.toString(), tagName)).filter(t -> t > 0 && t <= 15).max(Integer::compareTo).orElse(0));
 	}
 
 	private static int getLightLevelByTagName(String testee, String tagName) {
-		var prefix = DynamicLights.MOD_ID + ":" + tagName;
+		String prefix = DynamicLights.MOD_ID + ":" + tagName;
 		if(!testee.startsWith(prefix)) {
 			return 0;
 		}
@@ -40,7 +40,7 @@ public class ItemLightLevels {
 
 		int level = 0;
 		try {
-			var suffix = testee.substring(prefix.length()+1);
+			String suffix = testee.substring(prefix.length()+1);
 			level = Integer.parseInt(suffix);
 		} catch (Exception ignored) {}
 

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/blocks/BlockLitAir.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/blocks/BlockLitAir.java
@@ -4,8 +4,11 @@ import atomicstryker.dynamiclights.server.DynamicLights;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.AirBlock;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.Random;
 
@@ -13,6 +16,13 @@ public class BlockLitAir extends AirBlock {
 
     public BlockLitAir(Properties properties) {
         super(properties);
+        this.registerDefaultState(this.getStateDefinition().any().setValue(BlockStateProperties.POWER, 15));
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder);
+        builder.add(BlockStateProperties.POWER);
     }
 
     public boolean isRandomlyTicking(BlockState blockState) {

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/blocks/BlockLitCaveAir.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/blocks/BlockLitCaveAir.java
@@ -4,8 +4,11 @@ import atomicstryker.dynamiclights.server.DynamicLights;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.AirBlock;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 
 import java.util.Random;
 
@@ -13,6 +16,13 @@ public class BlockLitCaveAir extends AirBlock {
 
     public BlockLitCaveAir(Properties properties) {
         super(properties);
+        this.registerDefaultState(this.getStateDefinition().any().setValue(BlockStateProperties.POWER, 15));
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder);
+        builder.add(BlockStateProperties.POWER);
     }
 
     public boolean isRandomlyTicking(BlockState blockState) {

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/blocks/BlockLitWater.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/blocks/BlockLitWater.java
@@ -3,9 +3,12 @@ package atomicstryker.dynamiclights.server.blocks;
 import atomicstryker.dynamiclights.server.DynamicLights;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LiquidBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.material.FlowingFluid;
 
 import java.util.Random;
@@ -14,6 +17,13 @@ public class BlockLitWater extends LiquidBlock {
 
     public BlockLitWater(FlowingFluid flowingFluid, Properties properties) {
         super(flowingFluid, properties);
+        this.registerDefaultState(this.getStateDefinition().any().setValue(LEVEL, 0).setValue(BlockStateProperties.POWER, 15));
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        super.createBlockStateDefinition(builder);
+        builder.add(BlockStateProperties.POWER);
     }
 
     public boolean isRandomlyTicking(BlockState blockState) {

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/DroppedItemsLightSource.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/DroppedItemsLightSource.java
@@ -47,10 +47,9 @@ public class DroppedItemsLightSource {
     public void serverStartEvent(ServerAboutToStartEvent event) {
 
         LightConfig defaultConfig = new LightConfig();
-        String torchString = ItemConfigHelper.fromItemStack(new ItemStack(Blocks.TORCH));
-        defaultConfig.getItemsList().add(torchString);
-        defaultConfig.getItemsList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.GLOWSTONE)));
-        defaultConfig.getNotWaterProofList().add(torchString);
+        defaultConfig.getItemsList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.TORCH), 10));
+        defaultConfig.getItemsList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.GLOWSTONE), 15));
+        defaultConfig.getNotWaterProofList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.TORCH), 0));
 
         MinecraftServer server = event.getServer();
         File configFile = new File(server.getFile(""), File.separatorChar + "config" + File.separatorChar + "dynamiclights_droppeditems.cfg");
@@ -102,7 +101,7 @@ public class DroppedItemsLightSource {
     }
 
     private int getLightFromItemStack(ItemStack stack) {
-        return itemsMap.contains(stack) ? 15 : 0;
+        return itemsMap.getLightLevel(stack);
     }
 
     private class EntityItemAdapter implements IDynamicLightSource {
@@ -116,7 +115,7 @@ public class DroppedItemsLightSource {
             lightLevel = 0;
             enabled = false;
             entity = eI;
-            notWaterProof = notWaterProofItems.contains(eI.getItem());
+            notWaterProof = notWaterProofItems.getLightLevel(eI.getItem()) > 0;
         }
 
         /**

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/DroppedItemsLightSource.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/DroppedItemsLightSource.java
@@ -4,6 +4,7 @@ import atomicstryker.dynamiclights.server.DynamicLights;
 import atomicstryker.dynamiclights.server.GsonConfig;
 import atomicstryker.dynamiclights.server.IDynamicLightSource;
 import atomicstryker.dynamiclights.server.ItemConfigHelper;
+import atomicstryker.dynamiclights.server.ItemLightLevels;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -101,6 +102,13 @@ public class DroppedItemsLightSource {
     }
 
     private int getLightFromItemStack(ItemStack stack) {
+        // First check whether the item has a tag that makes it emit light
+        int level = ItemLightLevels.getLightFromItemStack(stack, "dropped");
+        if(level > 0 && level <= 15) {
+            return level;
+        }
+
+        // Then use our config file
         return itemsMap.getLightLevel(stack);
     }
 

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/DroppedItemsLightSource.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/DroppedItemsLightSource.java
@@ -5,6 +5,7 @@ import atomicstryker.dynamiclights.server.GsonConfig;
 import atomicstryker.dynamiclights.server.IDynamicLightSource;
 import atomicstryker.dynamiclights.server.ItemConfigHelper;
 import atomicstryker.dynamiclights.server.ItemLightLevels;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -113,6 +114,7 @@ public class DroppedItemsLightSource {
     }
 
     private class EntityItemAdapter implements IDynamicLightSource {
+        private static final ResourceLocation NOT_WATERPROOF_TAG = new ResourceLocation(DynamicLights.MOD_ID, "not_waterproof");
 
         private ItemEntity entity;
         private int lightLevel;
@@ -124,6 +126,8 @@ public class DroppedItemsLightSource {
             enabled = false;
             entity = eI;
             notWaterProof = notWaterProofItems.getLightLevel(eI.getItem()) > 0;
+            // 1.18.2: notWaterProof = notWaterProof || eI.getItem().getTags().anyMatch(rl -> rl.equals(NOT_WATERPROOF_TAG));
+            notWaterProof = notWaterProof || eI.getItem().getItem().getTags().contains(NOT_WATERPROOF_TAG);
         }
 
         /**

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/PlayerSelfLightSource.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/PlayerSelfLightSource.java
@@ -4,6 +4,7 @@ import atomicstryker.dynamiclights.server.DynamicLights;
 import atomicstryker.dynamiclights.server.GsonConfig;
 import atomicstryker.dynamiclights.server.IDynamicLightSource;
 import atomicstryker.dynamiclights.server.ItemConfigHelper;
+import atomicstryker.dynamiclights.server.ItemLightLevels;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Mth;
@@ -147,6 +148,13 @@ public class PlayerSelfLightSource {
     }
 
     private int getLightFromItemStack(ItemStack stack) {
+        // First check whether the item has a tag that makes it emit light
+        int level = ItemLightLevels.getLightFromItemStack(stack, "self");
+        if(level > 0 && level <= 15) {
+            return level;
+        }
+
+        // Then use our config file
         return itemsMap.getLightLevel(stack);
     }
 

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/PlayerSelfLightSource.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/PlayerSelfLightSource.java
@@ -6,6 +6,7 @@ import atomicstryker.dynamiclights.server.IDynamicLightSource;
 import atomicstryker.dynamiclights.server.ItemConfigHelper;
 import atomicstryker.dynamiclights.server.ItemLightLevels;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
@@ -33,6 +34,7 @@ import java.util.HashMap;
  * Handheld Items and Armor can give off Light through this Module.
  */
 public class PlayerSelfLightSource {
+    private static final ResourceLocation NOT_WATERPROOF_TAG = new ResourceLocation(DynamicLights.MOD_ID, "not_waterproof");
 
     private static final Logger LOGGER = LogManager.getLogger();
     private static ItemConfigHelper itemsMap;
@@ -109,7 +111,8 @@ public class PlayerSelfLightSource {
                 if (event.player.isOnFire()) {
                     playerLightSourceContainer.lightLevel = 15;
                 } else {
-                    if (checkPlayerWater(event.player) && notWaterProofItems.getLightLevel(item) > 0) {
+                    // 1.18.2: if (checkPlayerWater(event.player) && (notWaterProofItems.getLightLevel(item) > 0 || item.getTags().anyMatch(rl -> rl.equals(NOT_WATERPROOF_TAG)))) {
+                    if (checkPlayerWater(event.player) && (notWaterProofItems.getLightLevel(item) > 0 || item.getItem().getTags().contains(NOT_WATERPROOF_TAG))) {
                         playerLightSourceContainer.lightLevel = 0;
                         LOGGER.trace("Self light tick, water blocked light!");
                         for (ItemStack armor : event.player.getInventory().armor) {

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/PlayerSelfLightSource.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/modules/PlayerSelfLightSource.java
@@ -47,10 +47,9 @@ public class PlayerSelfLightSource {
     public void serverStartEvent(ServerAboutToStartEvent event) {
 
         LightConfig defaultConfig = new LightConfig();
-        String torchString = ItemConfigHelper.fromItemStack(new ItemStack(Blocks.TORCH));
-        defaultConfig.getItemsList().add(torchString);
-        defaultConfig.getItemsList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.GLOWSTONE)));
-        defaultConfig.getNotWaterProofList().add(torchString);
+        defaultConfig.getItemsList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.TORCH), 10));
+        defaultConfig.getItemsList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.GLOWSTONE), 15));
+        defaultConfig.getNotWaterProofList().add(ItemConfigHelper.fromItemStack(new ItemStack(Blocks.TORCH), 0));
 
         MinecraftServer server = event.getServer();
         File configFile = new File(server.getFile(""), File.separatorChar + "config" + File.separatorChar + "dynamiclights_selflight.cfg");
@@ -109,11 +108,11 @@ public class PlayerSelfLightSource {
                 if (event.player.isOnFire()) {
                     playerLightSourceContainer.lightLevel = 15;
                 } else {
-                    if (checkPlayerWater(event.player) && notWaterProofItems.contains(item)) {
+                    if (checkPlayerWater(event.player) && notWaterProofItems.getLightLevel(item) > 0) {
                         playerLightSourceContainer.lightLevel = 0;
                         LOGGER.trace("Self light tick, water blocked light!");
                         for (ItemStack armor : event.player.getInventory().armor) {
-                            if (!notWaterProofItems.contains(armor)) {
+                            if (notWaterProofItems.getLightLevel(armor) <= 0) {
                                 playerLightSourceContainer.lightLevel = Math.max(playerLightSourceContainer.lightLevel, getLightFromItemStack(armor));
                             }
                         }
@@ -148,10 +147,7 @@ public class PlayerSelfLightSource {
     }
 
     private int getLightFromItemStack(ItemStack stack) {
-        if (itemsMap.contains(stack)) {
-            return 15;
-        }
-        return 0;
+        return itemsMap.getLightLevel(stack);
     }
 
     private void enableLight(PlayerLightSourceContainer container) {

--- a/DynamicLights/src/main/resources/data/dynamiclights/tags/items/dropped.json
+++ b/DynamicLights/src/main/resources/data/dynamiclights/tags/items/dropped.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"minecraft:glowstone_dust"
+  ]
+}

--- a/DynamicLights/src/main/resources/data/dynamiclights/tags/items/dropped_8.json
+++ b/DynamicLights/src/main/resources/data/dynamiclights/tags/items/dropped_8.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"minecraft:redstone_torch"
+  ]
+}

--- a/DynamicLights/src/main/resources/data/dynamiclights/tags/items/not_waterproof.json
+++ b/DynamicLights/src/main/resources/data/dynamiclights/tags/items/not_waterproof.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"minecraft:redstone_torch"
+  ]
+}

--- a/DynamicLights/src/main/resources/data/dynamiclights/tags/items/self.json
+++ b/DynamicLights/src/main/resources/data/dynamiclights/tags/items/self.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"minecraft:glowstone_dust"
+  ]
+}

--- a/DynamicLights/src/main/resources/data/dynamiclights/tags/items/self_5.json
+++ b/DynamicLights/src/main/resources/data/dynamiclights/tags/items/self_5.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"minecraft:redstone_torch"
+  ]
+}


### PR DESCRIPTION
Hey there!

This pull requests adds two features to dynamic lights:
- Varying light levels for items, e.g. redstone torches can emit less light instead of the hardcoded 15
- Support for configuring items that emit light using various item tags

## Varying light levels
The first two commits handle this feature.
The first commit gives the 3 BlockLit* an additional `power` blockstate property. (With this a few more "model missing" lines are being thrown at game start, since there is no blockstate definition present)
The second commit makes use of this property by allowing it to be configured in the existing config files.

## Item Tags
The third commit makes the two currently existing light sources aware of various `dynamiclights:*` item tags.
A pack or mod dev can now add various items by assigning tags to them. This is particularly useful when exact nbt matching isn't desired (e.g. if a torch gets renamed in an anvil it should still emit light). For exact NBT matches the original config system should be used.

The tags are:
```
dynamiclights:self (light level 15)
dynamiclights:self_1 (light level 1)
...
dynamiclights_self_8 (light level 8)
...
dynamiclights:self_15 (light level 15)
```
And the same with `dropped` instead of `self`.

The fourth commit adds a rather straight forward `dynamiclights:not_waterproof` tag.

This PR also includes some data tags that you might want to tweak or delete for better default values?

Hope these are useful improvements.
Happy to change and improve things in this PR further.