### PR TITLE
fix logspam caused by missing models

### DIFF
--- a/DynamicLights/src/generated/resources/.cache/af6b71d80a7bad2e79730e7a7b72cf91265d7018
+++ b/DynamicLights/src/generated/resources/.cache/af6b71d80a7bad2e79730e7a7b72cf91265d7018
@@ -1,0 +1,4 @@
+// 1.20.1	2023-11-11T03:45:54.0868385	Block States: dynamiclights
+3dff9e1ec59415779195d2abfa9f07bc17b428a1 assets/dynamiclights/blockstates/lit_air.json
+3dff9e1ec59415779195d2abfa9f07bc17b428a1 assets/dynamiclights/blockstates/lit_cave_air.json
+e5a33b4a2db42195222fa1709b3d9533ac41e453 assets/dynamiclights/blockstates/lit_water.json

--- a/DynamicLights/src/generated/resources/assets/dynamiclights/blockstates/lit_air.json
+++ b/DynamicLights/src/generated/resources/assets/dynamiclights/blockstates/lit_air.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/air"
+    }
+  }
+}

--- a/DynamicLights/src/generated/resources/assets/dynamiclights/blockstates/lit_cave_air.json
+++ b/DynamicLights/src/generated/resources/assets/dynamiclights/blockstates/lit_cave_air.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/air"
+    }
+  }
+}

--- a/DynamicLights/src/generated/resources/assets/dynamiclights/blockstates/lit_water.json
+++ b/DynamicLights/src/generated/resources/assets/dynamiclights/blockstates/lit_water.json
@@ -1,0 +1,7 @@
+{
+  "variants": {
+    "": {
+      "model": "minecraft:block/water"
+    }
+  }
+}

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLights.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/DynamicLights.java
@@ -3,6 +3,7 @@ package atomicstryker.dynamiclights.server;
 import atomicstryker.dynamiclights.server.blocks.BlockLitAir;
 import atomicstryker.dynamiclights.server.blocks.BlockLitCaveAir;
 import atomicstryker.dynamiclights.server.blocks.BlockLitWater;
+import atomicstryker.dynamiclights.server.datagen.ModDatagen;
 import atomicstryker.dynamiclights.server.modules.DroppedItemsLightSource;
 import atomicstryker.dynamiclights.server.modules.PlayerSelfLightSource;
 import net.minecraft.core.BlockPos;
@@ -99,6 +100,7 @@ public class DynamicLights {
         // this one is for RegistryEvent
         final IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.register(DynamicLights.class);
+        modEventBus.addListener(ModDatagen::start);
 
         // this one is for FMLServerStartedEvent, WorldTickEvent
         MinecraftForge.EVENT_BUS.register(this);
@@ -118,7 +120,7 @@ public class DynamicLights {
     public void onAddReloadListener(AddReloadListenerEvent event) {
         // we need to clear our item -> light level cache on reload
         LOGGER.debug("Adding reload listener for light level cache");
-        event.addListener(new SimplePreparableReloadListener() {
+        event.addListener(new SimplePreparableReloadListener<>() {
 
             @Override
             protected @NotNull Object prepare(@NotNull ResourceManager resourceManager, @NotNull ProfilerFiller profilerFiller) {

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModBlockStateProvider.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModBlockStateProvider.java
@@ -1,0 +1,21 @@
+package atomicstryker.dynamiclights.server.datagen;
+
+import atomicstryker.dynamiclights.server.DynamicLights;
+import net.minecraft.data.PackOutput;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.client.model.generators.BlockStateProvider;
+import net.minecraftforge.common.data.ExistingFileHelper;
+
+public class ModBlockStateProvider extends BlockStateProvider {
+    public ModBlockStateProvider(PackOutput output, ExistingFileHelper exFileHelper) {
+        super(output, DynamicLights.MOD_ID, exFileHelper);
+    }
+
+    @Override
+    protected void registerStatesAndModels() {
+        final ResourceLocation airModel = new ResourceLocation("block/air");
+        simpleBlock(DynamicLights.LIT_AIR_BLOCK.get(),models().getExistingFile(airModel));
+        simpleBlock(DynamicLights.LIT_CAVE_AIR_BLOCK.get(),models().getExistingFile(airModel));
+        simpleBlock(DynamicLights.LIT_WATER_BLOCK.get(),models().getExistingFile(new ResourceLocation("block/water")));
+    }
+}

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModBlockStateProvider.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModBlockStateProvider.java
@@ -6,6 +6,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.model.generators.BlockStateProvider;
 import net.minecraftforge.common.data.ExistingFileHelper;
 
+/**
+ * @author Tfarcenim
+ *
+ * Class for creating blockstate jsons and their included models
+ */
 public class ModBlockStateProvider extends BlockStateProvider {
     public ModBlockStateProvider(PackOutput output, ExistingFileHelper exFileHelper) {
         super(output, DynamicLights.MOD_ID, exFileHelper);
@@ -14,6 +19,7 @@ public class ModBlockStateProvider extends BlockStateProvider {
     @Override
     protected void registerStatesAndModels() {
         final ResourceLocation airModel = new ResourceLocation("block/air");
+
         simpleBlock(DynamicLights.LIT_AIR_BLOCK.get(),models().getExistingFile(airModel));
         simpleBlock(DynamicLights.LIT_CAVE_AIR_BLOCK.get(),models().getExistingFile(airModel));
         simpleBlock(DynamicLights.LIT_WATER_BLOCK.get(),models().getExistingFile(new ResourceLocation("block/water")));

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModDatagen.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModDatagen.java
@@ -5,13 +5,21 @@ import net.minecraft.data.PackOutput;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import net.minecraftforge.data.event.GatherDataEvent;
 
+/**
+ * @author Tfarcenim
+ * <p>
+ * Datagenerator for assets and data that gets included in the mod
+ */
 public class ModDatagen {
 
     public static void start(GatherDataEvent event) {
+        
         DataGenerator dataGenerator = event.getGenerator();
         PackOutput packOutput = dataGenerator.getPackOutput();
         ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
+
         boolean client = event.includeClient();
-        dataGenerator.addProvider(client,new ModBlockStateProvider(packOutput,existingFileHelper));
+
+        dataGenerator.addProvider(client, new ModBlockStateProvider(packOutput, existingFileHelper));
     }
 }

--- a/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModDatagen.java
+++ b/DynamicLights/src/main/java/atomicstryker/dynamiclights/server/datagen/ModDatagen.java
@@ -1,0 +1,17 @@
+package atomicstryker.dynamiclights.server.datagen;
+
+import net.minecraft.data.DataGenerator;
+import net.minecraft.data.PackOutput;
+import net.minecraftforge.common.data.ExistingFileHelper;
+import net.minecraftforge.data.event.GatherDataEvent;
+
+public class ModDatagen {
+
+    public static void start(GatherDataEvent event) {
+        DataGenerator dataGenerator = event.getGenerator();
+        PackOutput packOutput = dataGenerator.getPackOutput();
+        ExistingFileHelper existingFileHelper = event.getExistingFileHelper();
+        boolean client = event.includeClient();
+        dataGenerator.addProvider(client,new ModBlockStateProvider(packOutput,existingFileHelper));
+    }
+}


### PR DESCRIPTION
This fixes the several hundred lines of logspam that is caused by the lit blocks not having models, this PR gives them models and datagen so that doesn't happen.

Attached is a snippet of what I see when using the mod as a dependency, I'm fixing it on my end for now, but I made this PR so others could have the fix as well.

![idea64_PKHUsPCT6l](https://github.com/AtomicStryker/atomicstrykers-minecraft-mods/assets/44327798/370e99db-352f-47b9-a677-a68b07845598)